### PR TITLE
fix: ensure the target output is esm or cjs

### DIFF
--- a/packages/client-http/tsconfig.cjs.json
+++ b/packages/client-http/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "build/cjs",
     "tsBuildInfoFile": "./build/types/tsconfig.cjs.tsbuildinfo"
   },

--- a/packages/client-http/tsconfig.esm.json
+++ b/packages/client-http/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "ES2015",
     "outDir": "build/esm",
     "tsBuildInfoFile": "./build/types/tsconfig.esm.tsbuildinfo"
   },

--- a/packages/integration-react/tsconfig.cjs.json
+++ b/packages/integration-react/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "build/cjs",
     "tsBuildInfoFile": "./build/types/tsconfig.cjs.tsbuildinfo"
   },

--- a/packages/integration-react/tsconfig.esm.json
+++ b/packages/integration-react/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "ES2015",
     "outDir": "build/esm",
     "tsBuildInfoFile": "./build/types/tsconfig.esm.tsbuildinfo"
   },

--- a/packages/openfeature-server-provider/tsconfig.cjs.json
+++ b/packages/openfeature-server-provider/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "build/cjs",
     "tsBuildInfoFile": "./build/types/tsconfig.cjs.tsbuildinfo"
   },

--- a/packages/openfeature-server-provider/tsconfig.esm.json
+++ b/packages/openfeature-server-provider/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "ES2015",
     "outDir": "build/esm",
     "tsBuildInfoFile": "./build/types/tsconfig.esm.tsbuildinfo"
   },

--- a/packages/openfeature-web-provider/tsconfig.cjs.json
+++ b/packages/openfeature-web-provider/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "build/cjs",
     "tsBuildInfoFile": "./build/types/tsconfig.cjs.tsbuildinfo"
   },

--- a/packages/openfeature-web-provider/tsconfig.esm.json
+++ b/packages/openfeature-web-provider/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "ES2015",
     "outDir": "build/esm",
     "tsBuildInfoFile": "./build/types/tsconfig.esm.tsbuildinfo"
   },


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Builds were not correctly using the common js format

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/sytle run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
