### PR TITLE
chore: add team members as codeowners [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Billlynch @andreas-karlsson @tonyskn @ammar1x
+* @Billlynch @andreas-karlsson @tonyskn @ammar1x @varmenise


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Adding team members to the list of code owners to approve PRs

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/sytle run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
