### PR TITLE
fix(server): do not cache request

### DIFF
--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -6,8 +6,7 @@
   "main": "build/cjs/index.js",
   "types": "build/types/index.d.ts",
   "dependencies": {
-    "@spotify-confidence/client-http": "^0.0.2",
-    "fast-deep-equal": "^3.1.3"
+    "@spotify-confidence/client-http": "^0.0.2"
   },
   "peerDependencies": {
     "@openfeature/js-sdk": "^1.4.2"

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -108,6 +108,13 @@ describe('ConfidenceServerProvider', () => {
     expect(instanceUnderTest.status).toEqual(ProviderStatus.READY);
   });
 
+  it('should make a network request on each flag resolve', async () => {
+    await instanceUnderTest.resolveBooleanEvaluation('testFlag.bool', false, {}, dummyConsole);
+    await instanceUnderTest.resolveBooleanEvaluation('testFlag.bool', false, {}, dummyConsole);
+
+    expect(resolveMock).toHaveBeenCalledTimes(2);
+  });
+
   describe('apply', () => {
     it('should send an apply event', async () => {
       await instanceUnderTest.resolveBooleanEvaluation('testFlag.bool', false, {}, dummyConsole);


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Previously we were caching the server request of a flag on the context, this can result in issues when handling multiple concurrent requests, also it can mean we never update to reflect changes made in the confidence console

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/sytle run on changed files
- [ ] Tests added for new functionality
- [x] Regression tests added for bug fixes
