### PR TITLE
refactor get flag to throw open feature errors and handle targeting key error

### DIFF
--- a/packages/client-http/src/client/Configuration.ts
+++ b/packages/client-http/src/client/Configuration.ts
@@ -6,6 +6,7 @@ export namespace Configuration {
     Match = 'RESOLVE_REASON_MATCH',
     NoSegmentMatch = 'RESOLVE_REASON_NO_SEGMENT_MATCH',
     NoTreatmentMatch = 'RESOLVE_REASON_NO_TREATMENT_MATCH',
+    TargetingKeyError = 'RESOLVE_REASON_TARGETING_KEY_ERROR',
     Archived = 'RESOLVE_REASON_FLAG_ARCHIVED',
   }
 

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -1,4 +1,11 @@
-import { FlagNotFoundError, Logger, ParseError, ProviderStatus, TypeMismatchError } from '@openfeature/js-sdk';
+import {
+  FlagNotFoundError,
+  Logger,
+  ParseError,
+  ProviderStatus,
+  TypeMismatchError,
+  InvalidContextError,
+} from '@openfeature/js-sdk';
 import { ConfidenceClient, Configuration } from '@spotify-confidence/client-http';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 
@@ -65,6 +72,13 @@ const dummyConfiguration: Configuration = {
       value: undefined,
       schema: 'undefined',
     },
+    ['targeting-error-flag']: {
+      name: 'targeting-error-flag',
+      variant: '',
+      reason: Configuration.ResolveReason.TargetingKeyError,
+      value: { enabled: true },
+      schema: { enabled: 'boolean' },
+    },
   },
   resolveToken: 'before-each',
   context: {},
@@ -92,6 +106,12 @@ describe('ConfidenceServerProvider', () => {
     await instanceUnderTest.resolveBooleanEvaluation('testFlag.bool', false, {}, dummyConsole);
 
     expect(resolveMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw invalid context error when the reason from confidence is targeting key error', async () => {
+    expect(() =>
+      instanceUnderTest.resolveBooleanEvaluation('targeting-error-flag.enabled', false, {}, dummyConsole),
+    ).rejects.toThrow(InvalidContextError);
   });
 
   describe('resolveBooleanEvaluation', () => {

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, Logger, ProviderStatus } from '@openfeature/web-sdk';
+import { FlagNotFoundError, Logger, ParseError, ProviderStatus, TypeMismatchError } from '@openfeature/js-sdk';
 import { ConfidenceClient, Configuration } from '@spotify-confidence/client-http';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 
@@ -125,33 +125,21 @@ describe('ConfidenceServerProvider', () => {
     });
 
     it('should return default if the flag is not found', async () => {
-      const actual = await instanceUnderTest.resolveBooleanEvaluation('notARealFlag.bool', false, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: false,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        reason: 'ERROR',
-      });
+      expect(() =>
+        instanceUnderTest.resolveBooleanEvaluation('notARealFlag.bool', false, {}, dummyConsole),
+      ).rejects.toThrow(new FlagNotFoundError('Flag "notARealFlag" was not found'));
     });
 
     it('should return default if the flag requested is the wrong type', async () => {
-      const actual = await instanceUnderTest.resolveBooleanEvaluation('testFlag.str', false, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: false,
-        errorCode: ErrorCode.TYPE_MISMATCH,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveBooleanEvaluation('testFlag.str', false, {}, dummyConsole)).rejects.toThrow(
+        TypeMismatchError,
+      );
     });
 
     it('should return default if the value requested is not in the flag schema', async () => {
-      const actual = await instanceUnderTest.resolveBooleanEvaluation('testFlag.404', false, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: false,
-        errorCode: ErrorCode.PARSE_ERROR,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveBooleanEvaluation('testFlag.404', false, {}, dummyConsole)).rejects.toThrow(
+        ParseError,
+      );
     });
   });
 
@@ -201,33 +189,21 @@ describe('ConfidenceServerProvider', () => {
     });
 
     it('should return default if the flag is not found', async () => {
-      const actual = await instanceUnderTest.resolveNumberEvaluation('notARealFlag.int', 1, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 1,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveNumberEvaluation('notARealFlag.int', 1, {}, dummyConsole)).rejects.toThrow(
+        FlagNotFoundError,
+      );
     });
 
     it('should return default if the flag requested is the wrong type', async () => {
-      const actual = await instanceUnderTest.resolveNumberEvaluation('testFlag.str', 1, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 1,
-        errorCode: ErrorCode.TYPE_MISMATCH,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveNumberEvaluation('testFlag.str', 1, {}, dummyConsole)).rejects.toThrow(
+        TypeMismatchError,
+      );
     });
 
     it('should return default if the value requested is not in the flag schema', async () => {
-      const actual = await instanceUnderTest.resolveNumberEvaluation('testFlag.404', 1, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 1,
-        errorCode: ErrorCode.PARSE_ERROR,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveNumberEvaluation('testFlag.404', 1, {}, dummyConsole)).rejects.toThrow(
+        ParseError,
+      );
     });
   });
 
@@ -255,43 +231,27 @@ describe('ConfidenceServerProvider', () => {
     });
 
     it('should return default if the flag is not found', async () => {
-      const actual = await instanceUnderTest.resolveStringEvaluation('notARealFlag.str', 'default', {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 'default',
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        reason: 'ERROR',
-      });
+      expect(() =>
+        instanceUnderTest.resolveStringEvaluation('notARealFlag.str', 'default', {}, dummyConsole),
+      ).rejects.toThrow(new FlagNotFoundError('Flag "notARealFlag" was not found'));
     });
 
     it('should return default if the flag requested is the wrong type', async () => {
-      const actual = await instanceUnderTest.resolveStringEvaluation('testFlag.int', 'default', {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 'default',
-        errorCode: ErrorCode.TYPE_MISMATCH,
-        reason: 'ERROR',
-      });
+      expect(() =>
+        instanceUnderTest.resolveStringEvaluation('testFlag.int', 'default', {}, dummyConsole),
+      ).rejects.toThrow(TypeMismatchError);
     });
 
     it('should return default if the flag requested is the wrong type from nested obj', async () => {
-      const actual = await instanceUnderTest.resolveStringEvaluation('testFlag.obj.int', 'default', {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 'default',
-        errorCode: ErrorCode.TYPE_MISMATCH,
-        reason: 'ERROR',
-      });
+      expect(() =>
+        instanceUnderTest.resolveStringEvaluation('testFlag.obj.int', 'default', {}, dummyConsole),
+      ).rejects.toThrow(TypeMismatchError);
     });
 
     it('should return default if the value requested is not in the flag schema', async () => {
-      const actual = await instanceUnderTest.resolveStringEvaluation('testFlag.404', 'default', {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: 'default',
-        errorCode: ErrorCode.PARSE_ERROR,
-        reason: 'ERROR',
-      });
+      expect(() =>
+        instanceUnderTest.resolveStringEvaluation('testFlag.404', 'default', {}, dummyConsole),
+      ).rejects.toThrow(ParseError);
     });
   });
 
@@ -338,8 +298,8 @@ describe('ConfidenceServerProvider', () => {
     });
 
     it('should resolve a full object with type mismatch default', async () => {
-      expect(
-        await instanceUnderTest.resolveObjectEvaluation(
+      expect(() =>
+        instanceUnderTest.resolveObjectEvaluation(
           'testFlag.obj',
           {
             testBool: false,
@@ -347,43 +307,25 @@ describe('ConfidenceServerProvider', () => {
           {},
           dummyConsole,
         ),
-      ).toEqual({
-        errorCode: 'TYPE_MISMATCH',
-        reason: 'ERROR',
-        value: {
-          testBool: false,
-        },
-      });
+      ).rejects.toThrow(TypeMismatchError);
     });
 
     it('should return default if the flag is not found', async () => {
-      const actual = await instanceUnderTest.resolveObjectEvaluation('notARealFlag.obj', {}, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: {},
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveObjectEvaluation('notARealFlag.obj', {}, {}, dummyConsole)).rejects.toThrow(
+        new FlagNotFoundError('Flag "notARealFlag" was not found'),
+      );
     });
 
     it('should return default if the flag requested is the wrong type', async () => {
-      const actual = await instanceUnderTest.resolveObjectEvaluation('testFlag.str', {}, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: {},
-        errorCode: ErrorCode.TYPE_MISMATCH,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveObjectEvaluation('testFlag.str', {}, {}, dummyConsole)).rejects.toThrow(
+        TypeMismatchError,
+      );
     });
 
     it('should return default if the value requested is not in the flag schema', async () => {
-      const actual = await instanceUnderTest.resolveObjectEvaluation('testFlag.404', {}, {}, dummyConsole);
-
-      expect(actual).toEqual({
-        value: {},
-        errorCode: ErrorCode.PARSE_ERROR,
-        reason: 'ERROR',
-      });
+      expect(() => instanceUnderTest.resolveObjectEvaluation('testFlag.404', {}, {}, dummyConsole)).rejects.toThrow(
+        ParseError,
+      );
     });
   });
 });

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.ts
@@ -2,6 +2,7 @@ import {
   ErrorCode,
   EvaluationContext,
   FlagNotFoundError,
+  InvalidContextError,
   JsonValue,
   Logger,
   ParseError,
@@ -58,6 +59,10 @@ export class ConfidenceServerProvider implements Provider {
     if (!flag) {
       logger.warn('Flag "%s" was not found', flagName);
       throw new FlagNotFoundError(`Flag "${flagName}" was not found`);
+    }
+
+    if (flag.reason === Configuration.ResolveReason.TargetingKeyError) {
+      throw new InvalidContextError();
     }
 
     if (Configuration.ResolveReason.NoSegmentMatch === flag.reason) {

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -2,6 +2,7 @@ import {
   EvaluationContext,
   FlagNotFoundError,
   GeneralError,
+  InvalidContextError,
   Logger,
   OpenFeatureAPI,
   ParseError,
@@ -79,6 +80,13 @@ const dummyConfiguration: Configuration = {
       reason: Configuration.ResolveReason.NoSegmentMatch,
       value: undefined,
       schema: 'undefined',
+    },
+    ['targeting-error-flag']: {
+      name: 'targeting-error-flag',
+      variant: '',
+      reason: Configuration.ResolveReason.TargetingKeyError,
+      value: { enabled: true },
+      schema: { enabled: 'boolean' },
     },
   },
   resolveToken: 'before-each',
@@ -231,6 +239,19 @@ describe('ConfidenceProvider', () => {
 
       expect(mockApply).toHaveBeenCalledWith(dummyConfiguration.resolveToken, 'testFlag');
     });
+  });
+
+  it('should throw invalid context error when the reason from confidence is targeting key error', async () => {
+    await instanceUnderTest.initialize(dummyContext);
+
+    expect(() =>
+      instanceUnderTest.resolveBooleanEvaluation(
+        'targeting-error-flag.enabled',
+        false,
+        dummyEvaluationContext,
+        dummyConsole,
+      ),
+    ).toThrow(InvalidContextError);
   });
 
   describe('resolveBooleanEvaluation', () => {

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -2,6 +2,7 @@ import {
   EvaluationContext,
   FlagNotFoundError,
   GeneralError,
+  InvalidContextError,
   JsonValue,
   Logger,
   OpenFeatureEventEmitter,
@@ -109,6 +110,10 @@ export class ConfidenceWebProvider implements Provider {
     if (!flag) {
       logger.warn('Flag "%s" was not found', flagName);
       throw new FlagNotFoundError(`Flag "${flagName}" was not found`);
+    }
+
+    if (flag.reason === Configuration.ResolveReason.TargetingKeyError) {
+      throw new InvalidContextError();
     }
 
     if (Configuration.ResolveReason.NoSegmentMatch === flag.reason) {


### PR DESCRIPTION
## Hi There, I just made a Pull Request!
Currently we set default value, error code and error message manually in the providers, this can make reading the getFlag function more difficult. OpenFeature's SDK will catch OF errors and map these in the exact same way. So we can simplify the logic with these errors. This is pre-work to make apply logic easier to adjust in the near future. 

Also added throwing invalid context error when confidence returns with a reason of targeting key error

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
