### PR TITLE
docs(react): add note on setting provider before setting context

### DIFF
--- a/packages/integration-react/README.md
+++ b/packages/integration-react/README.md
@@ -23,6 +23,10 @@ ProviderEvents events will be emitted only when we are done with the network req
 network response. If the network response failed, default values will be returned on flag evaluation, if the network
 request is successful we update the flags and then emit `ProviderEvents.Ready`.
 
+Notes:
+
+- It's advised not to perform `setContext` while `setProvider` is running, you can await setting the context first, or listen to the `ProviderEvent.Ready` via a handler on `OpenFeaure`.
+
 ```tsx
 import React, { useEffect } from 'react';
 import { createConfidenceWebProvider } from '@spotify-confidence/openfeature-web-provider';
@@ -35,12 +39,13 @@ const provider = createConfidenceWebProvider({
   fetchImplementation: window.fetch.bind(window),
   timeout: 1000,
 });
-OpenFeature.setProvider(provider);
 
 const App = () => {
   useEffect(() => {
     OpenFeature.setContext({
       targetingKey: 'myTargetingKey',
+    }).then(() => {
+      OpenFeature.setProvider(provider);
     });
   }, []);
 


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

An issue was pointed out that in the web provider docs we talk about not setting the provider before the context because of the issues with resolving with no context triggering a Provider ready event, meaning the UI might show with the default values before flashing to the actual values once the setContext call has completed. The PR updates to docs to make sure that issue is surfaced for people only viewing the react documentation.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [x] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
