### PR TITLE
Add global url

### DIFF
--- a/examples/node/src/index.js
+++ b/examples/node/src/index.js
@@ -3,7 +3,6 @@ import { OpenFeature } from '@openfeature/js-sdk';
 
 const provider = createConfidenceServerProvider({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-  region: 'eu',
   fetchImplementation: fetch,
   timeout: 1000,
 });

--- a/packages/client-http/src/client/ConfidenceClient.test.ts
+++ b/packages/client-http/src/client/ConfidenceClient.test.ts
@@ -78,6 +78,63 @@ describe('ConfidenceClient', () => {
       );
     });
 
+    it.each`
+      region       | url
+      ${'eu'}      | ${'https://resolver.eu.confidence.dev/v1/flags:resolve'}
+      ${'us'}      | ${'https://resolver.us.confidence.dev/v1/flags:resolve'}
+      ${'global'}  | ${'https://resolver.confidence.dev/v1/flags:resolve'}
+      ${undefined} | ${'https://resolver.confidence.dev/v1/flags:resolve'}
+    `(`should use the correct url for region $region`, async ({ region, url }) => {
+      mockFetch.mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            resolvedFlags: [],
+            resolveToken: '',
+          }),
+      });
+
+      const regionBasedInstance = new ConfidenceClient({
+        clientSecret: 'test-secret',
+        fetchImplementation: mockFetch,
+        apply: true,
+        region,
+        sdk: {
+          id: 'SDK_ID_JS_WEB_PROVIDER',
+          version: 'TESTING',
+        },
+        timeout: 10,
+      });
+
+      await regionBasedInstance.resolve({ targeting_key: 'a' }, { apply: false, flags: ['test-flag'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(url, expect.anything());
+    });
+
+    it(`should default to the global region`, async () => {
+      mockFetch.mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            resolvedFlags: [],
+            resolveToken: '',
+          }),
+      });
+
+      const regionBasedInstance = new ConfidenceClient({
+        clientSecret: 'test-secret',
+        fetchImplementation: mockFetch,
+        apply: true,
+        sdk: {
+          id: 'SDK_ID_JS_WEB_PROVIDER',
+          version: 'TESTING',
+        },
+        timeout: 10,
+      });
+
+      await regionBasedInstance.resolve({ targeting_key: 'a' }, { apply: false, flags: ['test-flag'] });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://resolver.confidence.dev/v1/flags:resolve', expect.anything());
+    });
+
     it('should call resolve with the context', async () => {
       mockFetch.mockResolvedValue({
         json: () =>

--- a/packages/client-http/src/client/ConfidenceClient.ts
+++ b/packages/client-http/src/client/ConfidenceClient.ts
@@ -39,7 +39,7 @@ export type ConfidenceClientOptions = {
   fetchImplementation: typeof fetch;
   clientSecret: string;
   apply: boolean;
-  region: 'eu' | 'us';
+  region?: 'global' | 'eu' | 'us';
   baseUrl?: string;
   sdk: SDK;
   timeout: number;
@@ -66,9 +66,10 @@ export class ConfidenceClient {
     if (options.baseUrl) {
       this.baseUrl = options.baseUrl;
     } else {
-      this.baseUrl = `https://resolver.${options.region}.confidence.dev`;
+      this.baseUrl = getConfidenceUrl(options.region);
     }
   }
+
   async resolve(context: ResolveContext, options?: { apply?: boolean; flags: string[] }): Promise<Configuration> {
     const payload: ResolveRequest = {
       clientSecret: this.clientSecret,
@@ -112,6 +113,13 @@ export class ConfidenceClient {
       body: JSON.stringify(payload),
     });
   }
+}
+
+function getConfidenceUrl(region?: ConfidenceClientOptions['region']): string {
+  if (region === 'global' || !region) {
+    return 'https://resolver.confidence.dev';
+  }
+  return `https://resolver.${region}.confidence.dev`;
 }
 
 function resolvedFlagToFlag(flag: ResolvedFlag): Configuration.Flag {

--- a/packages/integration-react/README.md
+++ b/packages/integration-react/README.md
@@ -35,7 +35,6 @@ import { useStringValue } from '@spotify-confidence/integration-react';
 
 const provider = createConfidenceWebProvider({
   clientSecret: 'mysecret',
-  region: 'eu',
   fetchImplementation: window.fetch.bind(window),
   timeout: 1000,
 });

--- a/packages/integration-react/src/ReactAdapter.e2e.test.tsx
+++ b/packages/integration-react/src/ReactAdapter.e2e.test.tsx
@@ -16,7 +16,6 @@ const TestComponent = () => {
 const confidenceProvider = createConfidenceWebProvider({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
   fetchImplementation: fetch as any,
-  region: 'eu',
   timeout: 1000,
 });
 

--- a/packages/openfeature-server-provider/README.md
+++ b/packages/openfeature-server-provider/README.md
@@ -23,7 +23,6 @@ import { OpenFeature } from '@openfeature/js-sdk';
 
 const provider = createConfidenceServerProvider({
   clientSecret: 'your-client-secret',
-  region: 'eu',
   fetchImplementation: fetch,
   timeout: 1000,
 });
@@ -39,6 +38,18 @@ client
   .then(result => {
     console.log('result:', result);
   });
+```
+
+## Region
+
+The region option is used to set the region for the network request to the Confidence backend. When the region is not set, the default (global) region will be used.
+The current regions are: `eu` and `us`, the region can be set as follows:
+
+```ts
+const provider = createConfidenceServerProvider({
+  region: 'eu', // or 'us'
+  // ... other options
+});
 ```
 
 ## Timeout

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
@@ -15,7 +15,6 @@ describe('ConfidenceServerProvider E2E tests', () => {
             } as Response),
         );
       },
-      region: 'eu',
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 1000,
     });

--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -1,11 +1,11 @@
 import { Provider } from '@openfeature/js-sdk';
 
-import { ConfidenceClient } from '@spotify-confidence/client-http';
+import { ConfidenceClient, ConfidenceClientOptions } from '@spotify-confidence/client-http';
 
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 
 type ConfidenceProviderFactoryOptions = {
-  region: 'eu' | 'us';
+  region?: ConfidenceClientOptions['region'];
   fetchImplementation: typeof fetch;
   clientSecret: string;
   baseUrl?: string;

--- a/packages/openfeature-web-provider/README.md
+++ b/packages/openfeature-web-provider/README.md
@@ -29,7 +29,6 @@ import { OpenFeature, OpenFeatureAPI } from '@openfeature/web-sdk';
 
 const provider = createConfidenceWebProvider({
   clientSecret: 'mysecret',
-  region: 'eu',
   fetchImplementation: window.fetch.bind(window),
   timeout: 1000,
 });
@@ -47,6 +46,18 @@ Notes:
 
 - It's advised not to perform `setContext` while `setProvider` is running, you can await setting the context first, or listen to the `ProviderEvent.Ready` via a handler on `OpenFeaure`.
 - It's advised not to perform resolves while `setProvider` and `setContext` are running: resolves might return the default value with reason `STALE` during such operations.
+
+## Region
+
+The region option is used to set the region for the network request to the Confidence backend. When the region is not set, the default (global) region will be used.
+The current regions are: `eu` and `us`, the region can be set as follows:
+
+```ts
+const provider = createConfidenceWebProvider({
+  region: 'eu', // or 'us'
+  // ... other options
+});
+```
 
 ## Timeout
 

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
@@ -15,7 +15,6 @@ describe('ConfidenceHTTPProvider E2E tests', () => {
             } as Response),
         );
       },
-      region: 'eu',
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 1000,
     });

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -1,9 +1,9 @@
 import { Provider } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
-import { ConfidenceClient } from '@spotify-confidence/client-http';
+import { ConfidenceClient, ConfidenceClientOptions } from '@spotify-confidence/client-http';
 
 type ConfidenceWebProviderFactoryOptions = {
-  region: 'eu' | 'us';
+  region?: ConfidenceClientOptions['region'];
   fetchImplementation: typeof fetch;
   clientSecret: string;
   baseUrl?: string;


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

This PR allows you to opt of selecting a region for your resolver, to use the default (global) region. You can also manually input 'global' to be explicit. The default is now to use the global resolver.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [x] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [x] Tested in a corresponding example app
