### PR TITLE
fix: Duplicate apply bug

### DIFF
--- a/packages/client-http/src/ApplyManager.test.ts
+++ b/packages/client-http/src/ApplyManager.test.ts
@@ -130,17 +130,17 @@ describe('ApplyManager', () => {
 
   it('should not resend events if the buffer overflows before the previous apply has completed', () => {
     for (let i = 0; i < 10; i++) instanceUnderTest.apply('some-token', `apply-test${i}`);
-    
+
     expect(applyMock).toHaveBeenCalledTimes(3);
     jest.advanceTimersByTime(100);
     expect(applyMock).toHaveBeenCalledTimes(4);
   });
-  
+
   it('should not attempt to send empty apply events', () => {
     instanceUnderTest.apply('some-token', `apply-test`);
     instanceUnderTest.flush();
     expect(applyMock).toHaveBeenCalledTimes(1);
-    
+
     instanceUnderTest.flush(); // nothing left to send
     expect(applyMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/client-http/src/ApplyManager.test.ts
+++ b/packages/client-http/src/ApplyManager.test.ts
@@ -1,10 +1,10 @@
 import { ConfidenceClient } from './client';
 import { ApplyManager } from './ApplyManager';
 
-const resolveMock = jest.fn();
+const applyMock = jest.fn();
 const mockClient = {
   resolve: jest.fn(),
-  apply: resolveMock,
+  apply: applyMock,
 } as jest.MockedObject<ConfidenceClient>;
 
 describe('ApplyManager', () => {
@@ -17,7 +17,7 @@ describe('ApplyManager', () => {
       maxBufferSize: 3,
       client: mockClient,
     });
-    resolveMock.mockResolvedValue({});
+    applyMock.mockResolvedValue({});
     jest.useFakeTimers();
     jest.setSystemTime(fakeDate);
   });
@@ -30,12 +30,12 @@ describe('ApplyManager', () => {
     instanceUnderTest.apply('some-token', 'apply-test');
 
     jest.advanceTimersByTime(99);
-    expect(resolveMock).toHaveBeenCalledTimes(0);
+    expect(applyMock).toHaveBeenCalledTimes(0);
 
     jest.advanceTimersByTime(1);
-    expect(resolveMock).toHaveBeenCalledTimes(1);
+    expect(applyMock).toHaveBeenCalledTimes(1);
 
-    expect(resolveMock).toHaveBeenCalledWith(
+    expect(applyMock).toHaveBeenCalledWith(
       [
         {
           flag: 'flags/apply-test',
@@ -55,12 +55,12 @@ describe('ApplyManager', () => {
     instanceUnderTest.apply('some-token', 'apply-test1');
     const secondApplyTime = new Date().toISOString();
 
-    expect(resolveMock).toHaveBeenCalledTimes(0);
+    expect(applyMock).toHaveBeenCalledTimes(0);
 
     jest.advanceTimersByTime(100);
-    expect(resolveMock).toHaveBeenCalledTimes(1);
+    expect(applyMock).toHaveBeenCalledTimes(1);
 
-    expect(resolveMock).toHaveBeenCalledWith(
+    expect(applyMock).toHaveBeenCalledWith(
       [
         {
           flag: 'flags/apply-test',
@@ -81,7 +81,7 @@ describe('ApplyManager', () => {
 
     jest.advanceTimersByTime(100);
 
-    expect(resolveMock).toHaveBeenCalledWith(
+    expect(applyMock).toHaveBeenCalledWith(
       [
         {
           flag: 'flags/apply-test1',
@@ -90,7 +90,7 @@ describe('ApplyManager', () => {
       ],
       'some-token1',
     );
-    expect(resolveMock).toHaveBeenCalledWith(
+    expect(applyMock).toHaveBeenCalledWith(
       [
         {
           flag: 'flags/apply-test2',
@@ -108,8 +108,8 @@ describe('ApplyManager', () => {
     instanceUnderTest.apply('some-token', 'apply-test1');
     instanceUnderTest.apply('some-token', 'apply-test2');
 
-    expect(resolveMock).toHaveBeenCalledTimes(1);
-    expect(resolveMock).toHaveBeenCalledWith(
+    expect(applyMock).toHaveBeenCalledTimes(1);
+    expect(applyMock).toHaveBeenCalledWith(
       [
         {
           flag: 'flags/apply-test',
@@ -126,5 +126,11 @@ describe('ApplyManager', () => {
       ],
       'some-token',
     );
+  });
+
+  it('should not resend events if the buffer overflows before the previous apply has completed', () => {
+    for (let i = 0; i < 10; i++) instanceUnderTest.apply('some-token', `apply-test${i}`);
+
+    expect(applyMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/client-http/src/ApplyManager.test.ts
+++ b/packages/client-http/src/ApplyManager.test.ts
@@ -130,7 +130,18 @@ describe('ApplyManager', () => {
 
   it('should not resend events if the buffer overflows before the previous apply has completed', () => {
     for (let i = 0; i < 10; i++) instanceUnderTest.apply('some-token', `apply-test${i}`);
-
+    
     expect(applyMock).toHaveBeenCalledTimes(3);
+    jest.advanceTimersByTime(100);
+    expect(applyMock).toHaveBeenCalledTimes(4);
+  });
+  
+  it('should not attempt to send empty apply events', () => {
+    instanceUnderTest.apply('some-token', `apply-test`);
+    instanceUnderTest.flush();
+    expect(applyMock).toHaveBeenCalledTimes(1);
+    
+    instanceUnderTest.flush(); // nothing left to send
+    expect(applyMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/client-http/src/ApplyManager.ts
+++ b/packages/client-http/src/ApplyManager.ts
@@ -7,8 +7,8 @@ export interface ApplyManagerOptions {
 }
 
 type TokenRecord = {
-  pendingApply: AppliedFlag[];
-  seenFlags: Set<string>;
+  readonly pendingApply: AppliedFlag[];
+  readonly seenFlags: Set<string>;
 };
 
 export class ApplyManager {
@@ -26,6 +26,7 @@ export class ApplyManager {
 
   async flush(): Promise<void> {
     for (const [resolve_token, { pendingApply }] of Array.from(this.tokenRecords.entries())) {
+      if (!pendingApply.length) continue;
       // remove all flags while trying
       const flagsToSend = pendingApply.splice(0, pendingApply.length);
       this.client.apply(flagsToSend, resolve_token).catch(() => {

--- a/packages/client-http/src/ApplyManager.ts
+++ b/packages/client-http/src/ApplyManager.ts
@@ -6,9 +6,13 @@ export interface ApplyManagerOptions {
   client: ConfidenceClient;
 }
 
+type TokenRecord = {
+  pendingApply: AppliedFlag[];
+  seenFlags: Set<string>;
+};
+
 export class ApplyManager {
-  private resolveTokenPending: Map<string, AppliedFlag[]> = new Map();
-  private resolveTokenSeen: Map<string, Set<string>> = new Map();
+  private readonly tokenRecords: Map<string, TokenRecord> = new Map();
   private readonly timeout: number;
   private readonly maxBufferSize: number;
   private client: ConfidenceClient;
@@ -21,54 +25,46 @@ export class ApplyManager {
   }
 
   async flush(): Promise<void> {
-    for (const resolve_token of Array.from(this.resolveTokenPending.keys())) {
-      const flagsToSend = this.resolveTokenPending.get(resolve_token) || [];
-
-      if (flagsToSend.length === 0) {
-        continue;
-      }
-
-      try {
-        this.client.apply(flagsToSend, resolve_token).then(() => {
-          this.resolveTokenPending.set(resolve_token, []);
-        });
-      } catch (e: unknown) {
-        // TODO log errors
-      }
+    for (const [resolve_token, { pendingApply }] of Array.from(this.tokenRecords.entries())) {
+      // remove all flags while trying
+      const flagsToSend = pendingApply.splice(0, pendingApply.length);
+      this.client.apply(flagsToSend, resolve_token).catch(() => {
+        // re-add flags on failure
+        pendingApply.push(...flagsToSend);
+      });
     }
   }
 
   apply(resolveToken: string, flagName: string) {
-    if (!resolveToken) {
-      return;
-    }
-    const confidenceFlagName = `flags/${flagName}`;
+    if (!resolveToken) return;
 
-    if (this.resolveTokenSeen.get(resolveToken)?.has(flagName)) {
-      return;
-    }
+    const tokenRecord = this.getTokenRecord(resolveToken);
 
-    const appliedFlag: AppliedFlag = {
-      flag: confidenceFlagName,
+    if (tokenRecord.seenFlags.has(flagName)) return;
+
+    tokenRecord.seenFlags.add(flagName);
+
+    tokenRecord.pendingApply.push({
+      flag: `flags/${flagName}`,
       applyTime: new Date().toISOString(),
-    };
-
-    if (!this.resolveTokenPending.has(resolveToken)) {
-      this.resolveTokenPending.set(resolveToken, [appliedFlag]);
-      this.resolveTokenSeen.set(resolveToken, new Set([flagName]));
-    } else {
-      this.resolveTokenPending.get(resolveToken)?.push(appliedFlag);
-      this.resolveTokenSeen.get(resolveToken)?.add(confidenceFlagName);
-    }
+    });
 
     if (this.flushTimeout) {
       clearTimeout(this.flushTimeout);
     }
 
-    if ((this.resolveTokenPending.get(resolveToken)?.length || 0) >= this.maxBufferSize) {
+    if (tokenRecord.pendingApply.length >= this.maxBufferSize) {
       this.flush();
     } else {
       this.flushTimeout = setTimeout(() => this.flush(), this.timeout);
     }
+  }
+
+  private getTokenRecord(resolveToken: string): TokenRecord {
+    let tokenRecord = this.tokenRecords.get(resolveToken);
+    if (!tokenRecord) {
+      this.tokenRecords.set(resolveToken, (tokenRecord = { pendingApply: [], seenFlags: new Set() }));
+    }
+    return tokenRecord;
   }
 }


### PR DESCRIPTION
## Fix duplicate apply on buffer overflow
Before apply events could be duplicated if the ApplyManager was flushed (which happens on buffer overflow) while a apply request was already in progress. This is fixed by clearing pendingApply while a request is in progress and adding them back if the request fails. Also refactored the code a bit to make it easier to follow.

The apply logic still has some shortcomings, but these will be adressed in a followup PR.
#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [x] linter/style run on changed files
- [x] Regression tests added for bug fixes
