### PR TITLE
feat(client-http): improved retry logic

### DIFF
--- a/packages/client-http/src/fetch-util.test.ts
+++ b/packages/client-http/src/fetch-util.test.ts
@@ -1,0 +1,219 @@
+import { FetchBuilder } from './fetch-util';
+
+jest.useFakeTimers();
+
+describe('FetchBuilder', () => {
+  describe('abortPrevious', () => {
+    const response = new Response(null, { status: 200 });
+    const simpleFetchMock = jest.fn<Promise<Response>, [Request]>(
+      ({ signal }) =>
+        new Promise((resolve, reject) => {
+          signal.onabort = () => reject(signal.reason);
+          setTimeout(() => resolve(response), 100);
+        }),
+    );
+    it('should pass one request through', async () => {
+      const underTest = new FetchBuilder().abortPrevious().build(simpleFetchMock);
+
+      const result = underTest('http://www.spotify.com');
+      jest.runAllTimers();
+
+      expect(await result).toBe(response);
+    });
+
+    it('should abort first request when a second arrives', async () => {
+      const underTest = new FetchBuilder().abortPrevious().build(simpleFetchMock);
+
+      // we need to turn the catch into a result or node will complain about unh
+      expect(underTest('http://www.spotify.com')).rejects.toThrow('Request superseded');
+      expect(underTest('http://www.spotify.com')).resolves.toBe(response);
+
+      await jest.runAllTimersAsync();
+
+      expect.assertions(2);
+    });
+  });
+  describe('rateLimit', () => {
+    it('it keeps request rate under maxRate', async () => {
+      let requestCount = 0;
+      const simpleFetchMock = async () => {
+        requestCount++;
+        return new Response();
+      };
+
+      const rateLimitedFetch = new FetchBuilder().rateLimit(10).build(simpleFetchMock);
+
+      for (let i = 0; i < 30; i++) {
+        rateLimitedFetch('http://spotify.com');
+      }
+      await jest.advanceTimersByTimeAsync(0);
+
+      // the initial tokens are let through directly
+      expect(requestCount).toBe(10);
+      let prevCount = requestCount;
+      while (jest.getTimerCount() > 0) {
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(requestCount - prevCount <= 10).toBe(true);
+        prevCount = requestCount;
+      }
+
+      expect(requestCount).toBe(30);
+    });
+
+    it(`manages request rate`, async () => {
+      const startTime = Date.now();
+      const requestTimes: Record<string, number> = {};
+      const simpleFetchMock = async ({ url }: Request) => {
+        requestTimes[url] = Date.now() - startTime;
+        return new Response();
+      };
+
+      const rateLimitedFetch = new FetchBuilder()
+        .rateLimit(10, { maxTokens: 2, initialTokens: 2 })
+        .build(simpleFetchMock);
+
+      rateLimitedFetch('http://spotify.com/1');
+      rateLimitedFetch('http://spotify.com/2');
+      rateLimitedFetch('http://spotify.com/3');
+      rateLimitedFetch('http://spotify.com/4');
+
+      await jest.runAllTimersAsync();
+
+      expect(requestTimes).toEqual({
+        'http://spotify.com/1': 0,
+        'http://spotify.com/2': 0,
+        'http://spotify.com/3': 100,
+        'http://spotify.com/4': 200,
+      });
+    });
+
+    it(`doesn't wait on aborted requests`, async () => {
+      const startTime = Date.now();
+      const requestTimes: Record<string, number> = {};
+      const simpleFetchMock = async ({ url, signal }: Request) => {
+        signal.throwIfAborted();
+        requestTimes[url] = Date.now() - startTime;
+        return new Response();
+      };
+
+      const rateLimitedFetch = new FetchBuilder().rateLimit(10, { initialTokens: 0 }).build(simpleFetchMock);
+
+      const successHandler = jest.fn();
+      const abortHandler = jest.fn();
+
+      rateLimitedFetch('http://spotify.com/1').then(successHandler);
+      rateLimitedFetch('http://spotify.com/2', { signal: timeoutSignal(50) }).catch(abortHandler);
+      rateLimitedFetch('http://spotify.com/3').then(successHandler);
+
+      await jest.runAllTimersAsync();
+
+      expect(requestTimes).toEqual({
+        'http://spotify.com/1': 100,
+        'http://spotify.com/3': 200,
+      });
+
+      expect(abortHandler).toHaveBeenCalledTimes(1);
+      expect(successHandler).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('retry', () => {
+    it(`should retry`, async () => {
+      const startTime = Date.now();
+      const requestTimes: number[] = [];
+      const simpleFetchMock = async () => {
+        requestTimes.push(Date.now() - startTime);
+        throw new Error('some error');
+      };
+
+      const retryingFetch = new FetchBuilder().retry({ maxRetries: 3, delay: 100, backoff: 2 }).build(simpleFetchMock);
+
+      expect(retryingFetch('http://test.com')).rejects.toThrow('some error');
+
+      await jest.runAllTimersAsync();
+
+      expect(requestTimes).toEqual([0, 100, 300, 700]);
+    });
+  });
+
+  describe('timeout', () => {
+    it('aborts requests after timeout milliseconds', async () => {
+      const startTime = Date.now();
+      const simpleFetchMock = () => new Promise<Response>(() => {});
+      const timeoutFetch = new FetchBuilder().timeout(300).build(simpleFetchMock);
+
+      expect(timeoutFetch('http://test.com')).rejects.toThrow('timeout');
+
+      await jest.runAllTimersAsync();
+
+      expect(Date.now()).toBe(startTime + 300);
+    });
+  });
+
+  describe('rejectNotOk', () => {
+    const simpleFetchMock = jest.fn();
+
+    const rejectingFetch = new FetchBuilder().rejectNotOk().build(simpleFetchMock);
+
+    it('passes on 200 responses', async () => {
+      const response = new Response(null, { status: 200 });
+      simpleFetchMock.mockResolvedValue(response);
+      await expect(rejectingFetch('http://test.com')).resolves.toBe(response);
+    });
+
+    it('turns non 200 codes into errors', async () => {
+      for (const status of [301, 404, 500]) {
+        simpleFetchMock.mockResolvedValue(new Response(null, { status, statusText: 'error' }));
+        await expect(rejectingFetch('http://test.com')).rejects.toThrow(`${status}: error`);
+      }
+    });
+  });
+
+  describe('limitPending', () => {
+    const simpleFetchMock = jest.fn();
+
+    const limitedFetch = new FetchBuilder().limitPending(10).build(simpleFetchMock);
+
+    it('allows up to maxPending open requests', async () => {
+      const successful: Promise<Response>[] = [];
+
+      simpleFetchMock.mockImplementation(
+        () =>
+          new Promise(resolve => {
+            setTimeout(() => resolve(new Response()), 1);
+          }),
+      );
+      for (let i = 0; i < 10; i++) {
+        successful.push(limitedFetch('http://test.com'));
+      }
+      const failed = expect(limitedFetch('http://test.com')).rejects.toThrow('Number of pending requests exceeded');
+
+      await jest.advanceTimersByTimeAsync(1);
+
+      await Promise.all(successful);
+      await failed;
+
+      expect(simpleFetchMock).toHaveBeenCalledTimes(10);
+    });
+  });
+
+  describe('modifyRequest', () => {
+    it('can modify the request', async () => {
+      const simpleFetchMock = jest.fn();
+      simpleFetchMock.mockResolvedValue(new Response());
+      const requestModifyingFetch = new FetchBuilder()
+        .modifyRequest(async request => new Request(`${request.url}modified`, request))
+        .build(simpleFetchMock);
+
+      await requestModifyingFetch('http://test.com');
+
+      expect(simpleFetchMock).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://test.com/modified' }));
+    });
+  });
+});
+
+function timeoutSignal(milliseconds: number): AbortSignal {
+  const abortController = new AbortController();
+  setTimeout(() => abortController.abort(), milliseconds);
+  return abortController.signal;
+}

--- a/packages/client-http/src/fetch-util.ts
+++ b/packages/client-http/src/fetch-util.ts
@@ -1,0 +1,176 @@
+type Fetch = typeof fetch;
+
+type SimpleFetch = (request: Request) => Promise<Response>;
+type FetchPrimitive = (next: SimpleFetch) => SimpleFetch;
+
+export const enum TimeUnit {
+  SECOND = 1000,
+  MINUTE = 60 * TimeUnit.SECOND,
+}
+
+export class RequestError extends Error {}
+export class TimeoutError extends RequestError {
+  constructor() {
+    super('Request timed out');
+  }
+}
+
+export class FetchBuilder {
+  impl?: FetchPrimitive;
+
+  private compose(inner: FetchPrimitive): this {
+    const outer = this.impl;
+    this.impl = outer ? next => outer(inner(next)) : inner;
+    return this;
+  }
+
+  timeout(duration: number): this {
+    return this.compose(next => request => {
+      const [signal, abort] = abortController(request.signal);
+      // prefer using our own timeout over AbortSignal.timeout() since it plays well with fakeTimers in tests
+      const timeoutId = setTimeout(() => {
+        abort(new TimeoutError());
+      }, duration);
+      return next(new Request(request, { signal })).finally(() => {
+        clearTimeout(timeoutId);
+      });
+    });
+  }
+
+  abortPrevious(): this {
+    let abortPrevious: (() => void) | undefined;
+    return this.compose(next => request => {
+      abortPrevious?.();
+      const [abortableRequest, abort] = makeAbortable(request);
+      abortPrevious = () => abort(new RequestError('Request superseded'));
+      return next(abortableRequest);
+    });
+  }
+
+  rejectNotOk(): this {
+    return this.compose(
+      next => request =>
+        next(request).then(response => {
+          if (!response.ok) throw new RequestError(`${response.status}: ${response.statusText}`);
+          return response;
+        }),
+    );
+  }
+
+  limitPending(maxPending: number): this {
+    let pending = 0;
+    return this.compose(next => request => {
+      if (pending >= maxPending) return Promise.reject(new RequestError('Number of pending requests exceeded'));
+      pending++;
+      return next(request).finally(() => {
+        pending--;
+      });
+    });
+  }
+
+  rateLimit(tokenFillRate: number, { maxTokens = tokenFillRate, initialTokens = tokenFillRate } = {}) {
+    let lastRefillTime = Number.NEGATIVE_INFINITY;
+    let tokens = initialTokens;
+    let nextRun = Promise.resolve();
+
+    return this.compose(next => request => {
+      nextRun = nextRun
+        // catch the potential abort of the previous run
+        .catch(() => {})
+        .then(async () => {
+          refillTokens();
+          // we can only send a request if we have at least one token
+          if (tokens < 1) {
+            // wait until tokens is one
+            await abortableSleep(((1 - tokens) / tokenFillRate) * 1000, request.signal);
+          }
+        });
+      return nextRun.then(() => {
+        tokens--;
+        return next(request);
+      });
+    });
+
+    function refillTokens() {
+      const currentTime = Date.now();
+      // initialTokens might be higher than maxTokens, so we don't refill until we've dropped below maxTokens
+      if (Number.isFinite(lastRefillTime) && tokens < maxTokens) {
+        const elapsed = (currentTime - lastRefillTime) / 1000;
+        tokens = Math.min(maxTokens, tokens + elapsed * tokenFillRate);
+      }
+      lastRefillTime = currentTime;
+    }
+  }
+
+  retry({
+    maxRetries = Number.POSITIVE_INFINITY,
+    delay = 0,
+    maxDelay = Number.POSITIVE_INFINITY,
+    backoff = 2,
+    jitter = 0,
+  } = {}): this {
+    return this.compose(next => async request => {
+      let retryCount = 0;
+
+      const doRetry = async (e: unknown): Promise<Response> => {
+        // if there are no more attempts we throw the last error
+        if (retryCount >= maxRetries) throw e;
+
+        const jitterFactor = 1 + 2 * Math.random() * jitter - jitter;
+        await abortableSleep(jitterFactor * Math.min(maxDelay, delay * Math.pow(backoff, retryCount)), request.signal);
+        retryCount++;
+        return next(request.clone()).catch(doRetry);
+      };
+
+      return next(request.clone()).catch(doRetry);
+    });
+  }
+
+  modifyRequest(mod: (request: Request) => Promise<Request>): this {
+    return this.compose(next => async request => next(await mod(request)));
+  }
+
+  route(match: (url: string) => boolean, fetch: SimpleFetch) {
+    return this.compose(next => request => match(request.url) ? fetch(request) : next(request));
+  }
+
+  build(sink: SimpleFetch): Fetch {
+    const impl = this.impl ? this.impl(sink) : sink;
+    return (input, init) => impl(new Request(input, init));
+  }
+}
+
+function makeAbortable(request: Request): [request: Request, abort: (reason: unknown) => void] {
+  const [signal, abort] = abortController(request.signal);
+  return [new Request(request, { signal }), abort];
+}
+
+function abortController(...follow: AbortSignal[]): [signal: AbortSignal, abort: (reason: unknown) => void] {
+  const controller = new AbortController();
+
+  function listener(this: AbortSignal) {
+    controller.abort(this.reason);
+  }
+
+  for (const signal of follow) {
+    // request should always have signal, but the cross-fetch polyfill used in tests doesn't comply, hence this check
+    if (!signal) continue;
+    signal.addEventListener('abort', listener);
+  }
+  return [controller.signal, controller.abort.bind(controller)];
+}
+
+export function abortableSleep(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  if (milliseconds <= 0) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    if (signal) {
+      const abort = () => reject(signal.reason);
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      signal.addEventListener('abort', abort);
+    }
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/packages/client-http/src/fetch-util.ts
+++ b/packages/client-http/src/fetch-util.ts
@@ -1,6 +1,29 @@
+/**
+ * Convenient type alias for the full fetch API
+ */
 type Fetch = typeof fetch;
 
+/**
+ * The full fetch API has overloaded variants which makes it very cumbersome
+ * to compose, therefore we define SimpleFetch, as just the simplest of the fetch
+ * overloads.
+ *
+ * Hence fetch itself is of type SimpleFetch i.e.
+ * ```
+ * const simple:SimpleFetch = fetch // ok
+ * ```
+ *
+ * It's also easy to get back the full fetch API thanks to the Request constructor
+ * ```
+ * const fullFetch:Fetch = (input, init) => simple(new Request(input, init))
+ * ```
+ */
 type SimpleFetch = (request: Request) => Promise<Response>;
+
+/**
+ * A function that takes a SimpleFetch and returns a new SimpleFetch
+ * with some desired behavior applied.
+ */
 type FetchPrimitive = (next: SimpleFetch) => SimpleFetch;
 
 export const enum TimeUnit {
@@ -15,15 +38,63 @@ export class TimeoutError extends RequestError {
   }
 }
 
+/**
+ * Build a fetch function by adding "primitives" such as retry, rateLimit and timeout.
+ *
+ * Example usage:
+ * ```
+ * const customFetch = new FetchBuilder()
+ *    .timeout(1000)
+ *    .retry()
+ *    .rateLimit()
+ *    .build(fetch);
+ *
+ * const resp = await customFetch('http://test.com');
+ * ```
+ *
+ * The primitives apply in the same order they are written.
+ *
+ * @privateRemarks
+ *
+ * The primitive implementations all follow a common pattern of just adding a composition:
+ * ```
+ * noopPrimitive(): this {
+ *  return this.compose(next => async request => {
+ *    // here we're "in" a fetch call and could modify the request
+ *    const response = await next(request);
+ *    // after the upstream call, we could also modify the response
+ *    return response;
+ *  })
+ * }
+ * ```
+ *
+ */
 export class FetchBuilder {
   impl?: FetchPrimitive;
 
+  /**
+   * Compose a fetch primitive (inner) with the existing primitive in the builder (outer).
+   *
+   * @param inner - the primitive to add to the chain
+   * @returns the builder itself
+   */
   private compose(inner: FetchPrimitive): this {
     const outer = this.impl;
-    this.impl = outer ? next => outer(inner(next)) : inner;
+    if (outer) {
+      this.impl = next => outer(inner(next));
+    } else {
+      // in the initial state we don't have outer and no composition is needed
+      this.impl = inner;
+    }
     return this;
   }
 
+  /**
+   * Apply a timeout that aborts the ongoing request with a {@link TimeoutError}
+   *
+   * @param duration - milliseconds after which to abort
+   * @returns the builder itself
+   */
   timeout(duration: number): this {
     return this.compose(next => request => {
       const [signal, abort] = abortController(request.signal);
@@ -37,6 +108,11 @@ export class FetchBuilder {
     });
   }
 
+  /**
+   * Only allow one outstanding request. If a new request is made, the existing request it aborted with {@link RequestError}
+   *
+   * @returns the builder itself
+   */
   abortPrevious(): this {
     let abortPrevious: (() => void) | undefined;
     return this.compose(next => request => {
@@ -47,6 +123,11 @@ export class FetchBuilder {
     });
   }
 
+  /**
+   * Turn all non 200 responses into {@link RequestError} rejections.
+   *
+   * @returns the builder itself
+   */
   rejectNotOk(): this {
     return this.compose(
       next => request =>
@@ -57,6 +138,12 @@ export class FetchBuilder {
     );
   }
 
+  /**
+   * Only allow `maxPending` outstanding requests. Requests made while at the limit will directly reject with {@link RequestError}
+   *
+   * @param maxPending - the number of simultaneous requests supported
+   * @returns the builder itself
+   */
   limitPending(maxPending: number): this {
     let pending = 0;
     return this.compose(next => request => {
@@ -68,6 +155,17 @@ export class FetchBuilder {
     });
   }
 
+  /**
+   * Control the rate of requests with a "token bucket" scheme. Every request requires 1 token to proceed.
+   * Tokens are continuously produced at `tokenFillRate`, until `maxTokens`. This enables limited burstiness as
+   * requests are free to proceed as long as there are more than one token available. When less than one token
+   * is available requests are queued without bound. See {@link FetchBuilder.limitPending } to manage the queue size.
+   *
+   * @param tokenFillRate - tokens to produce per second
+   * @param options.maxTokens - the number of tokens to refill
+   * @param options.initialTokens - the initial number of tokens, can be larger than `maxTokens`
+   * @returns the builder itself
+   */
   rateLimit(tokenFillRate: number, { maxTokens = tokenFillRate, initialTokens = tokenFillRate } = {}) {
     let lastRefillTime = Number.NEGATIVE_INFINITY;
     let tokens = initialTokens;
@@ -102,6 +200,16 @@ export class FetchBuilder {
     }
   }
 
+  /**
+   * Retry rejected requests.
+   *
+   * @param options.maxRetries - the maximum number of retires, defaults to unbounded
+   * @param options.delay - the delay between retries, defaults to zero
+   * @param options.backoff - multiplier for exponentially increasing the delay, defaults to `2`
+   * @param options.jitter - random jitter as a ratio (.i.e `0.1` means ±10% jitter), defaults to zero
+   * @param options.maxDelay - the maximum duration at which backoff will no longer apply, defaults to unbounded
+   * @returns the builder itself
+   */
   retry({
     maxRetries = Number.POSITIVE_INFINITY,
     delay = 0,
@@ -126,25 +234,63 @@ export class FetchBuilder {
     });
   }
 
-  modifyRequest(mod: (request: Request) => Promise<Request>): this {
+  /**
+   * Modify the request.
+   *
+   * @param mod - a (possibly async) function to transform the request
+   * @returns the builder itself
+   */
+  modifyRequest(mod: (request: Request) => Promise<Request> | Request): this {
     return this.compose(next => async request => next(await mod(request)));
   }
 
+  /**
+   * Possibly forward requests to another fetch implementation based on url matching.
+   * Unmatched requests will proceed as usual.
+   *
+   * @param match - predicate matching the url
+   * @param fetch - the fetch implementation to receive matching requests
+   * @returns the builder itself
+   */
   route(match: (url: string) => boolean, fetch: SimpleFetch) {
     return this.compose(next => request => match(request.url) ? fetch(request) : next(request));
   }
 
+  /**
+   * Finish the primitive composition and return a full fetch implementation.
+   *
+   * @param sink - the fetch implementation to send the actual request
+   * @returns the built fetch implementation
+   */
   build(sink: SimpleFetch): Fetch {
     const impl = this.impl ? this.impl(sink) : sink;
     return (input, init) => impl(new Request(input, init));
   }
 }
 
+/**
+ * Simplifies the common task of making a request abortable, while also respecting an existing abort signal
+ * ```
+ * const [myRequest, abort] = makeAbortable(request);
+ * // myRequest is identical to request but can be aborted by calling abort(reason)
+ * ```
+ * @param request - the request to clone
+ * @returns tuple of the cloned request and its abort function
+ */
 function makeAbortable(request: Request): [request: Request, abort: (reason: unknown) => void] {
   const [signal, abort] = abortController(request.signal);
   return [new Request(request, { signal }), abort];
 }
 
+/**
+ * Utility function that simplifies working with AbortController:
+ * ```
+ * // signal will activate when abort is called OR when someOtherSignal activates
+ * const [signal, abort] = abortController(someOtherSignal);
+ * ```
+ * @param follow - optional AbortSignals that should be followed
+ * @returns tuple of signal and corresponding abort function
+ */
 function abortController(...follow: AbortSignal[]): [signal: AbortSignal, abort: (reason: unknown) => void] {
   const controller = new AbortController();
 

--- a/packages/client-http/src/index.ts
+++ b/packages/client-http/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
 export * from './ApplyManager';
+export * from './fetch-util';

--- a/packages/openfeature-web-provider/src/factory.test.ts
+++ b/packages/openfeature-web-provider/src/factory.test.ts
@@ -1,0 +1,149 @@
+import { abortableSleep } from '@spotify-confidence/client-http';
+import { withRequestLogic } from './factory';
+import { setMaxListeners } from 'node:events';
+const RESOLVE_ENDPOINT = 'https://resolver.confidence.dev/v1/flags:resolve';
+const APPLY_ENDPOINT = 'https://resolver.confidence.dev/v1/flags:apply';
+
+setMaxListeners(50);
+
+describe('withRequestLogic', () => {
+  const fetchMock = jest.fn<Promise<Response>, [Request]>();
+
+  let underTest: typeof fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    underTest = withRequestLogic(fetchMock);
+  });
+  afterEach(() => {
+    if (jest.getTimerCount() !== 0) throw new Error('test finished with remaining timers');
+    jest.useRealTimers();
+  });
+
+  it('should throw on unknown urls', async () => {
+    fetchMock.mockResolvedValue(new Response());
+
+    await expect(underTest('https://resolver.confidence.dev/v1/flags:bad')).rejects.toThrow(
+      'Unexpected url: https://resolver.confidence.dev/v1/flags:bad',
+    );
+  });
+
+  describe('resolve', () => {
+    function makeResolveRequest(timeout: number): Promise<Response> {
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => abortController.abort(), timeout);
+      return underTest(RESOLVE_ENDPOINT, { method: 'POST', body: '{}', signal: abortController.signal }).finally(() => {
+        clearTimeout(timeoutId);
+      });
+    }
+
+    it('should make retries until timeout', async () => {
+      const attempts: number[] = [];
+
+      fetchMock.mockImplementation(async ({ signal }) => {
+        signal.throwIfAborted();
+        attempts.push(Date.now());
+        return new Response(null, { status: 500 });
+      });
+
+      expect(makeResolveRequest(3000)).rejects.toThrow('This operation was aborted');
+
+      await jest.runAllTimersAsync();
+
+      expect(Date.now()).toBe(3000);
+      // the rate limiting allows three initial requests, then one per second
+      expect(attempts).toEqual([0, 0, 0, 1000, 2000]);
+    });
+
+    it('should abort the previous request', async () => {
+      fetchMock.mockImplementation(async ({ signal }) => {
+        await abortableSleep(100, signal);
+        return new Response();
+      });
+
+      expect(makeResolveRequest(1000)).rejects.toThrow('Request superseded');
+      expect(makeResolveRequest(1000)).resolves.toMatchObject({ status: 200 });
+
+      await jest.runAllTimersAsync();
+    });
+  });
+
+  describe('apply', () => {
+    function makeApplyRequest(): Promise<Response> {
+      return underTest(APPLY_ENDPOINT, { method: 'POST', body: '{}' });
+    }
+
+    it('should make retries until timeout', async () => {
+      let previousAttemptTime = Number.NEGATIVE_INFINITY;
+      const delays: number[] = [];
+
+      // make jitter predictable
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      fetchMock.mockImplementation(async ({ signal }) => {
+        signal.throwIfAborted();
+        const currentTime = Date.now();
+        if (Number.isFinite(previousAttemptTime)) {
+          delays.push((currentTime - previousAttemptTime) / 1000);
+        }
+        previousAttemptTime = currentTime;
+        return new Response(null, { status: 500 });
+      });
+
+      const doneTime = expect(makeApplyRequest())
+        .rejects.toThrow('Request timed out')
+        .then(() => Date.now());
+      await nextCall(fetchMock);
+      await jest.runAllTimersAsync();
+
+      // 30 min timeout
+      expect(await doneTime).toBe(1000 * 60 * 30);
+      // delay of 5s with exponential backoff and max delay of 5 min (300s)
+      expect(delays).toEqual([5, 10, 20, 40, 80, 160, 300, 300, 300, 300]);
+    });
+
+    it('rejects more than a thousand pending requests', async () => {
+      fetchMock.mockImplementation(async () => new Response());
+
+      for (let i = 0; i < 1000; i++) {
+        expect(makeApplyRequest()).resolves.toBeInstanceOf(Response);
+      }
+      expect(makeApplyRequest()).rejects.toThrow('Number of pending requests exceeded');
+      expect(makeApplyRequest()).rejects.toThrow('Number of pending requests exceeded');
+      await jest.runAllTimersAsync();
+      // we can make two requests per second, except for the first two which happen directly, so in total 499s
+      expect(Date.now() / 1000).toBe(499);
+    });
+
+    it('uses actual send time (irrespective of retry or rate limit)', async () => {
+      fetchMock.mockImplementation(async request => {
+        const { sendTime } = await request.json();
+        expect(sendTime).toBe(new Date().toISOString());
+        return new Response();
+      });
+
+      for (let i = 0; i < 10; i++) {
+        makeApplyRequest();
+      }
+      await nextCall(fetchMock);
+      await jest.runAllTimersAsync();
+      expect.assertions(10);
+    });
+  });
+});
+
+function nextCall(mock: jest.Mock): Promise<void> {
+  return new Promise(resolve => {
+    const impl = mock.getMockImplementation();
+
+    mock.mockImplementationOnce((...args) => {
+      let maybePromise: any;
+      try {
+        return (maybePromise = impl?.(...args)!);
+      } finally {
+        Promise.resolve(maybePromise).finally(resolve);
+      }
+    });
+  });
+}

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@openfeature/web-sdk';
 import { ConfidenceWebProvider } from './ConfidenceWebProvider';
-import { ConfidenceClient, ConfidenceClientOptions } from '@spotify-confidence/client-http';
+import { ConfidenceClient, ConfidenceClientOptions, FetchBuilder, TimeUnit } from '@spotify-confidence/client-http';
 
 type ConfidenceWebProviderFactoryOptions = {
   region?: ConfidenceClientOptions['region'];
@@ -17,7 +17,7 @@ export function createConfidenceWebProvider({
 }: ConfidenceWebProviderFactoryOptions): Provider {
   const confidenceClient = new ConfidenceClient({
     ...options,
-    fetchImplementation,
+    fetchImplementation: withRequestLogic(fetchImplementation),
     apply: options.apply === 'backend',
     sdk: {
       id: 'SDK_ID_JS_WEB_PROVIDER',
@@ -28,6 +28,42 @@ export function createConfidenceWebProvider({
   return new ConfidenceWebProvider(confidenceClient, {
     apply: options.apply || 'access',
   });
+}
+
+// exported for testing
+export function withRequestLogic(fetchImplementation: (request: Request) => Promise<Response>): typeof fetch {
+  const fetchResolve = new FetchBuilder()
+    // always cancel previous resolve
+    .abortPrevious()
+    // infinite retries without delay until aborted by timeout
+    .retry()
+    .rejectNotOk()
+    .rateLimit(1, { initialTokens: 3, maxTokens: 2 })
+    .build(fetchImplementation);
+
+  const fetchApply = new FetchBuilder()
+    .limitPending(1000)
+    .timeout(30 * TimeUnit.MINUTE)
+    .retry({ delay: 5 * TimeUnit.SECOND, backoff: 2, maxDelay: 5 * TimeUnit.MINUTE, jitter: 0.2 })
+    .rejectNotOk()
+    .rateLimit(2)
+    // update send-time before sending
+    .modifyRequest(async request => {
+      if (request.method === 'POST') {
+        const body = JSON.stringify({ ...(await request.json()), sendTime: new Date().toISOString() });
+        return new Request(request, { body });
+      }
+      return request;
+    })
+    .build(fetchImplementation);
+
+  return (
+    new FetchBuilder()
+      .route(url => url.endsWith('flags:resolve'), fetchResolve)
+      .route(url => url.endsWith('flags:apply'), fetchApply)
+      // throw so we notice changes in endpoints that should be handled here
+      .build(request => Promise.reject(new Error(`Unexpected url: ${request.url}`)))
+  );
 }
 
 function defaultFetchImplementation(): typeof fetch {

--- a/packages/openfeature-web-provider/src/index.ts
+++ b/packages/openfeature-web-provider/src/index.ts
@@ -1,2 +1,2 @@
 export type * from './ConfidenceWebProvider';
-export * from './factory';
+export { createConfidenceWebProvider } from './factory';


### PR DESCRIPTION
## First draft of some improved retry logic and rate limiting
_Note: This is still work in progress, if we're happy with the overall logic, more tests are needed_

This PR hardens the logic for making requests to our backend. This is achieved through a new class `FetchBuilder` which allows to augment the fetch client with some request logic primitives like `retry`, `rate-limit` and `timeout` etc.  These primitives are used to build two separate fetch clients for resolve and apply with the following goals:

### Calls to resolve flags:
- Whenever there is a new request, abort the previous one since there is no point in applying those stale values.
- Add a timeout to each call. This is the only user-configurable option and dictates how long the user is prepared to wait before giving up and falling back on default values.
- Retry unlimited number of times until the timeout
- Rate limit to a fixed number of requests per second (rate-limiting queues requests, but this is no problem since we always abort the previous request)

### Calls to apply flags:
- Retry each apply a fixed number of times
- Rate limit to a fixed number of requests per second. The queued up requests can grow indefinitely.

### On the rate limiting
The rate-limit primitive uses a "token bucket" approach. Tokens are filled up at the specified rate up to the maxTokens (which defaults to the same value as the rate). Each request waits until it can acquire a token. This allows for some burstiness of requests. For example with a rate of 10 rps, the client can is initially allowed to make 10 requests immediately, until the tokens are depleted after which every request is queued for 1/10 s. If the client slows down it's rate, the bucket can again fill up to it's maxTokens (10 in this example)

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
