### PR TITLE
feat: send sdk info with apply events

### DIFF
--- a/packages/client-http/src/client/ConfidenceClient.test.ts
+++ b/packages/client-http/src/client/ConfidenceClient.test.ts
@@ -260,6 +260,10 @@ describe('ConfidenceClient', () => {
           resolve_token: resolveToken,
           flags: flagsToApply,
           sendTime: fakeTime.toISOString(),
+          sdk: {
+            id: 'SDK_ID_JS_WEB_PROVIDER',
+            version: 'TESTING',
+          },
         }),
       });
     });

--- a/packages/client-http/src/client/ConfidenceClient.ts
+++ b/packages/client-http/src/client/ConfidenceClient.ts
@@ -5,6 +5,7 @@ type ApplyRequest = {
   resolve_token: string;
   flags: AppliedFlag[];
   sendTime: string;
+  sdk: SDK;
 };
 type SDK = {
   id: 'SDK_ID_JS_WEB_PROVIDER' | 'SDK_ID_JS_SERVER_PROVIDER';
@@ -107,6 +108,7 @@ export class ConfidenceClient {
       resolve_token: resolveToken,
       flags,
       sendTime: new Date().toISOString(),
+      sdk: this.sdk,
     };
     await this.fetchImplementation(`${this.baseUrl}/v1/flags:apply`, {
       method: 'POST',

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -6,7 +6,7 @@
   "main": "build/cjs/index.js",
   "types": "build/types/index.d.ts",
   "dependencies": {
-    "@spotify-confidence/client-http": "^0.1.4"
+    "@spotify-confidence/client-http": "0.1.4"
   },
   "devDependencies": {
     "@openfeature/core": "^0.0.24",

--- a/packages/openfeature-web-provider/package.json
+++ b/packages/openfeature-web-provider/package.json
@@ -6,7 +6,7 @@
   "main": "build/cjs/index.js",
   "types": "build/types/index.d.ts",
   "dependencies": {
-    "@spotify-confidence/client-http": "^0.1.4",
+    "@spotify-confidence/client-http": "0.1.4",
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,7 +3830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify-confidence/client-http@npm:^0.1.4, @spotify-confidence/client-http@workspace:packages/client-http":
+"@spotify-confidence/client-http@npm:0.1.4, @spotify-confidence/client-http@workspace:packages/client-http":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/client-http@workspace:packages/client-http"
   languageName: unknown
@@ -3873,7 +3873,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/client-http": "npm:^0.1.4"
+    "@spotify-confidence/client-http": "npm:0.1.4"
   peerDependencies:
     "@openfeature/server-sdk": ^1.10.0
   languageName: unknown
@@ -3885,7 +3885,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/client-http": "npm:^0.1.4"
+    "@spotify-confidence/client-http": "npm:0.1.4"
     fast-deep-equal: "npm:^3.1.3"
   peerDependencies:
     "@openfeature/web-sdk": ^0.4.11


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Start sending SDK information with apply events. The PR also pins the shared `@spotify-confidence/client-http` dependency to an exakt version so we can now the setup from just the provider version.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
