### PR TITLE
Use a default fetch implementation

### DIFF
--- a/customJestBrowserEnv.ts
+++ b/customJestBrowserEnv.ts
@@ -1,0 +1,12 @@
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+// this is needed to add the node fetch impl. to the JSDOM env.
+export default class CustomJestBrowserEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+    this.global.fetch = fetch;
+    this.global.Request = Request;
+    this.global.Response = Response;
+    // And any other missing globals
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
     {
       displayName: 'integration-react',
       testMatch: ['<rootDir>/packages/integration-react/src/**/*.test.ts*'],
-      testEnvironment: 'jsdom',
+      testEnvironment: './customJestBrowserEnv.ts',
       ...projectCommonConfig,
       setupFilesAfterEnv: ['jest-extended/all', '<rootDir>/packages/integration-react/jest.setup.ts'],
     },

--- a/packages/client-http/package.json
+++ b/packages/client-http/package.json
@@ -5,6 +5,10 @@
   "module": "build/esm/index.js",
   "main": "build/cjs/index.js",
   "types": "build/types/index.d.ts",
+  "engineStrict": true,
+  "engines": {
+    "node": ">=18.17.0"
+  },
   "scripts": {
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -21,7 +21,6 @@
     "@spotify-confidence/openfeature-web-provider": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
-    "@types/node-fetch": "^2.6.4",
     "@types/use-sync-external-store": "^0.0.4",
     "react": "^18.2.0"
   },

--- a/packages/integration-react/src/ReactAdapter.e2e.test.tsx
+++ b/packages/integration-react/src/ReactAdapter.e2e.test.tsx
@@ -14,7 +14,6 @@ const TestComponent = () => {
 
 const confidenceProvider = createConfidenceWebProvider({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-  fetchImplementation: fetch,
   timeout: 1000,
 });
 

--- a/packages/integration-react/src/ReactAdapter.e2e.test.tsx
+++ b/packages/integration-react/src/ReactAdapter.e2e.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import fetch from 'node-fetch';
 import { OpenFeatureAPI, ProviderEvents } from '@openfeature/web-sdk';
 import { act } from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
@@ -15,7 +14,7 @@ const TestComponent = () => {
 
 const confidenceProvider = createConfidenceWebProvider({
   clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-  fetchImplementation: fetch as any,
+  fetchImplementation: fetch,
   timeout: 1000,
 });
 

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
@@ -1,36 +1,18 @@
-import { OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
-import axios from 'axios';
+import { OpenFeature } from '@openfeature/server-sdk';
 import { createConfidenceServerProvider } from './factory';
 
 describe('ConfidenceServerProvider E2E tests', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     const confidenceProvider = createConfidenceServerProvider({
-      fetchImplementation: async (url, request): Promise<Response> => {
-        return await axios.post(url as string, request?.body).then(
-          resp =>
-            ({
-              json: async () => {
-                return resp.data;
-              },
-            } as Response),
-        );
-      },
+      fetchImplementation: fetch,
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
-      timeout: 1000,
-    });
-    const providerReadyPromise = new Promise<void>(resolve => {
-      OpenFeature.addHandler(ProviderEvents.Ready, () => {
-        resolve();
-      });
-    }).then(() => {
-      return OpenFeature.setContext({
-        targetingKey: 'test-a', // control
-      });
+      timeout: 2000,
     });
 
     OpenFeature.setProvider(confidenceProvider);
-
-    return providerReadyPromise;
+    OpenFeature.setContext({
+      targetingKey: 'test-a', // control
+    });
   });
 
   it('should resolve a boolean e2e', async () => {

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
@@ -4,7 +4,6 @@ import { createConfidenceServerProvider } from './factory';
 describe('ConfidenceServerProvider E2E tests', () => {
   beforeEach(() => {
     const confidenceProvider = createConfidenceServerProvider({
-      fetchImplementation: fetch,
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 2000,
     });

--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -6,15 +6,19 @@ import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 
 type ConfidenceProviderFactoryOptions = {
   region?: ConfidenceClientOptions['region'];
-  fetchImplementation: typeof fetch;
+  fetchImplementation?: typeof fetch;
   clientSecret: string;
   baseUrl?: string;
   timeout: number;
 };
 
-export function createConfidenceServerProvider(options: ConfidenceProviderFactoryOptions): Provider {
+export function createConfidenceServerProvider({
+  fetchImplementation = defaultFetchImplementation(),
+  ...options
+}: ConfidenceProviderFactoryOptions): Provider {
   const confidenceClient = new ConfidenceClient({
     ...options,
+    fetchImplementation,
     apply: true,
     sdk: {
       id: 'SDK_ID_JS_SERVER_PROVIDER',
@@ -23,4 +27,13 @@ export function createConfidenceServerProvider(options: ConfidenceProviderFactor
   });
 
   return new ConfidenceServerProvider(confidenceClient);
+}
+
+function defaultFetchImplementation(): typeof fetch {
+  if (!globalThis.fetch) {
+    throw new TypeError(
+      'No default fetch implementation found. Please provide provide the fetchImplementation option to createConfidenceServerProvider.',
+    );
+  }
+  return globalThis.fetch.bind(globalThis);
 }

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
@@ -4,7 +4,6 @@ import { createConfidenceWebProvider } from './factory';
 describe('ConfidenceHTTPProvider E2E tests', () => {
   beforeAll(() => {
     const confidenceProvider = createConfidenceWebProvider({
-      fetchImplementation: fetch,
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 1000,
     });
@@ -25,7 +24,6 @@ describe('ConfidenceHTTPProvider E2E tests', () => {
 
   it('should return defaults after the timeout', async () => {
     const confidenceProvider = createConfidenceWebProvider({
-      fetchImplementation: global.fetch.bind(global),
       region: 'eu',
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 0,

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
@@ -1,20 +1,10 @@
 import { OpenFeature, ProviderEvents } from '@openfeature/web-sdk';
-import axios from 'axios';
 import { createConfidenceWebProvider } from './factory';
 
 describe('ConfidenceHTTPProvider E2E tests', () => {
   beforeAll(() => {
     const confidenceProvider = createConfidenceWebProvider({
-      fetchImplementation: async (url, request): Promise<Response> => {
-        return await axios.post(url as string, request?.body).then(
-          resp =>
-            ({
-              json: async () => {
-                return resp.data;
-              },
-            } as Response),
-        );
-      },
+      fetchImplementation: fetch,
       clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
       timeout: 1000,
     });

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -4,16 +4,20 @@ import { ConfidenceClient, ConfidenceClientOptions } from '@spotify-confidence/c
 
 type ConfidenceWebProviderFactoryOptions = {
   region?: ConfidenceClientOptions['region'];
-  fetchImplementation: typeof fetch;
+  fetchImplementation?: typeof fetch;
   clientSecret: string;
   baseUrl?: string;
   apply?: 'access' | 'backend';
   timeout: number;
 };
 
-export function createConfidenceWebProvider(options: ConfidenceWebProviderFactoryOptions): Provider {
+export function createConfidenceWebProvider({
+  fetchImplementation = defaultFetchImplementation(),
+  ...options
+}: ConfidenceWebProviderFactoryOptions): Provider {
   const confidenceClient = new ConfidenceClient({
     ...options,
+    fetchImplementation,
     apply: options.apply === 'backend',
     sdk: {
       id: 'SDK_ID_JS_WEB_PROVIDER',
@@ -24,4 +28,13 @@ export function createConfidenceWebProvider(options: ConfidenceWebProviderFactor
   return new ConfidenceWebProvider(confidenceClient, {
     apply: options.apply || 'access',
   });
+}
+
+function defaultFetchImplementation(): typeof fetch {
+  if (!globalThis.fetch) {
+    throw new TypeError(
+      'No default fetch implementation found. Please provide provide the fetchImplementation option to createConfidenceWebProvider.',
+    );
+  }
+  return globalThis.fetch.bind(globalThis);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,34 +3830,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify-confidence/client-http@npm:0.1.4, @spotify-confidence/client-http@workspace:packages/client-http":
+"@spotify-confidence/client-http@npm:0.1.5, @spotify-confidence/client-http@workspace:packages/client-http":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/client-http@workspace:packages/client-http"
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/integration-react@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@spotify-confidence/integration-react@npm:0.1.3"
-  dependencies:
-    use-sync-external-store: "npm:^1.2.0"
-  peerDependencies:
-    "@openfeature/web-sdk": ^0.4.0
-    react-dom: ">=16 <19"
-  checksum: 10c0/55290b44a0dd8dd0165cd99ec3e2d64cbc2e9df4f676dbf1189bcb6b3f294181b9bc1209dfab2e59e39f84626496631e844efd6a37c61cb53ade2f65675e3434
-  languageName: node
-  linkType: hard
-
-"@spotify-confidence/integration-react@workspace:packages/integration-react":
+"@spotify-confidence/integration-react@npm:0.2.0, @spotify-confidence/integration-react@workspace:packages/integration-react":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/integration-react@workspace:packages/integration-react"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-web-provider": "npm:^0.1.5"
+    "@spotify-confidence/openfeature-web-provider": "npm:^0.2.0"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^14.0.0"
-    "@types/node-fetch": "npm:^2.6.4"
     "@types/use-sync-external-store": "npm:^0.0.4"
     react: "npm:^18.2.0"
     use-sync-external-store: "npm:^1.2.0"
@@ -3867,25 +3854,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/openfeature-server-provider@npm:0.1.5, @spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider":
+"@spotify-confidence/openfeature-server-provider@npm:0.2.0, @spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/client-http": "npm:0.1.4"
+    "@spotify-confidence/client-http": "npm:0.1.5"
   peerDependencies:
     "@openfeature/server-sdk": ^1.10.0
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/openfeature-web-provider@npm:0.1.5, @spotify-confidence/openfeature-web-provider@npm:^0.1.5, @spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider":
+"@spotify-confidence/openfeature-web-provider@npm:0.2.0, @spotify-confidence/openfeature-web-provider@npm:^0.2.0, @spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/client-http": "npm:0.1.4"
+    "@spotify-confidence/client-http": "npm:0.1.5"
     fast-deep-equal: "npm:^3.1.3"
   peerDependencies:
     "@openfeature/web-sdk": ^0.4.11
@@ -4590,16 +4577,6 @@ __metadata:
   version: 1.2.2
   resolution: "@types/minimist@npm:1.2.2"
   checksum: 10c0/f220f57f682bbc3793dab4518f8e2180faa79d8e2589c79614fd777d7182be203ba399020c3a056a115064f5d57a065004a32b522b2737246407621681b24137
-  languageName: node
-  linkType: hard
-
-"@types/node-fetch@npm:^2.6.4":
-  version: 2.6.4
-  resolution: "@types/node-fetch@npm:2.6.4"
-  dependencies:
-    "@types/node": "npm:*"
-    form-data: "npm:^3.0.0"
-  checksum: 10c0/e43e4670ed8b7693dbf660ac1450b14fcfcdd8efca1eb0f501b6ad95af2d1fa06f8541db03e9511e82a5fee510a238fe0913330c9a58f8ac6892b985f6dd993e
   languageName: node
   linkType: hard
 
@@ -14021,8 +13998,8 @@ __metadata:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.1.5"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.1.5"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.2.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.2.0"
     eslint: "npm:8.50.0"
     eslint-config-next: "npm:13.5.3"
     next: "npm:13.5.3"
@@ -14038,8 +14015,8 @@ __metadata:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.1.5"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.1.5"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.2.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.2.0"
     "@types/node": "npm:20.6.5"
     "@types/react": "npm:18.2.22"
     "@types/react-dom": "npm:18.2.7"
@@ -14189,7 +14166,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.1.5"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.2.0"
   languageName: unknown
   linkType: soft
 
@@ -14199,7 +14176,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.1.5"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.2.0"
   languageName: unknown
   linkType: soft
 
@@ -16621,8 +16598,8 @@ __metadata:
     "@babel/plugin-transform-react-jsx": "npm:^7.22.15"
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/integration-react": "npm:0.1.3"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.1.5"
+    "@spotify-confidence/integration-react": "npm:0.2.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.2.0"
     "@testing-library/dom": "npm:^7.29.6"
     "@testing-library/jest-dom": "npm:^5.14.1"
     "@testing-library/react": "npm:^13.0.0"


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

This PR updates all tests to use the global fetch implementation, both in browsers and NodeJS. Before we were using a mix of different hacked fetch implementations.

It also makes the `fetchImplementation` setting optional when creating a provider, and defaults this setting to use the global fetch, and throwing an error if it doesn't exist.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
