### PR TITLE
fix(client-http): do not retry aborted requests

### DIFF
--- a/packages/client-http/src/fetch-util.test.ts
+++ b/packages/client-http/src/fetch-util.test.ts
@@ -134,6 +134,17 @@ describe('FetchBuilder', () => {
 
       expect(requestTimes).toEqual([0, 100, 300, 700]);
     });
+
+    it(`shouldn't retry aborted requests`, async () => {
+      const simpleFetchMock = jest.fn().mockRejectedValue(new Error('aborted'));
+      const retryingFetch = new FetchBuilder().retry().build(simpleFetchMock);
+
+      expect(retryingFetch('http://test.com', { signal: AbortSignal.abort() })).rejects.toThrow();
+
+      await jest.runAllTimersAsync();
+
+      expect(simpleFetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('timeout', () => {

--- a/packages/client-http/src/fetch-util.ts
+++ b/packages/client-http/src/fetch-util.ts
@@ -221,6 +221,7 @@ export class FetchBuilder {
       let retryCount = 0;
 
       const doRetry = async (e: unknown): Promise<Response> => {
+        request.signal?.throwIfAborted();
         // if there are no more attempts we throw the last error
         if (retryCount >= maxRetries) throw e;
 


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

This fixes an edge case that if a request was already aborted when entering retry, the abort itself would trigger more retries.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing
- [ ] Relevant documentation updated
- [x] linter/style run on changed files
- [ ] Tests added for new functionality
- [x] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
