### PR TITLE
ci: allow lockfile changes in publish build

### DIFF
--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -43,6 +43,8 @@ jobs:
           scope: '@spotify-confidence'
       - name: Install dependencies
         shell: bash
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
         # No frozen lockfile because that doesn't play with release-please
         run: corepack enable && yarn install
       - name: Build

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,19 +3830,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify-confidence/client-http@npm:0.1.6, @spotify-confidence/client-http@workspace:packages/client-http":
+"@spotify-confidence/client-http@npm:0.3.0-rc.0, @spotify-confidence/client-http@workspace:packages/client-http":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/client-http@workspace:packages/client-http"
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/integration-react@npm:0.2.1, @spotify-confidence/integration-react@workspace:packages/integration-react":
+"@spotify-confidence/integration-react@npm:0.3.0-rc.0, @spotify-confidence/integration-react@workspace:packages/integration-react":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/integration-react@workspace:packages/integration-react"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-web-provider": "npm:^0.2.1"
+    "@spotify-confidence/openfeature-web-provider": "npm:^0.3.0-rc.0"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^14.0.0"
     "@types/use-sync-external-store": "npm:^0.0.4"
@@ -3854,36 +3854,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/openfeature-server-provider@npm:0.2.1, @spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider":
+"@spotify-confidence/openfeature-server-provider@npm:0.3.0-rc.0, @spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-server-provider@workspace:packages/openfeature-server-provider"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/sdk": "npm:0.0.1"
+    "@spotify-confidence/sdk": "npm:0.3.0-rc.0"
   peerDependencies:
     "@openfeature/server-sdk": ^1.10.0
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/openfeature-web-provider@npm:0.2.1, @spotify-confidence/openfeature-web-provider@npm:^0.2.1, @spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider":
+"@spotify-confidence/openfeature-web-provider@npm:0.3.0-rc.0, @spotify-confidence/openfeature-web-provider@npm:^0.3.0-rc.0, @spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/openfeature-web-provider@workspace:packages/openfeature-web-provider"
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/sdk": "npm:0.0.1"
+    "@spotify-confidence/sdk": "npm:0.3.0-rc.0"
     fast-deep-equal: "npm:^3.1.3"
   peerDependencies:
     "@openfeature/web-sdk": ^0.4.11
   languageName: unknown
   linkType: soft
 
-"@spotify-confidence/sdk@npm:0.0.1, @spotify-confidence/sdk@workspace:packages/sdk":
+"@spotify-confidence/sdk@npm:0.3.0-rc.0, @spotify-confidence/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local
   resolution: "@spotify-confidence/sdk@workspace:packages/sdk"
   dependencies:
-    "@spotify-confidence/client-http": "npm:0.1.6"
+    "@spotify-confidence/client-http": "npm:0.3.0-rc.0"
   languageName: unknown
   linkType: soft
 
@@ -14006,8 +14006,8 @@ __metadata:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.2.1"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.2.1"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.3.0-rc.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.3.0-rc.0"
     eslint: "npm:8.50.0"
     eslint-config-next: "npm:13.5.3"
     next: "npm:13.5.3"
@@ -14023,8 +14023,8 @@ __metadata:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.2.1"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.2.1"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.3.0-rc.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.3.0-rc.0"
     "@types/node": "npm:20.6.5"
     "@types/react": "npm:18.2.22"
     "@types/react-dom": "npm:18.2.7"
@@ -14174,7 +14174,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.2.1"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.3.0-rc.0"
   languageName: unknown
   linkType: soft
 
@@ -14184,7 +14184,7 @@ __metadata:
   dependencies:
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/server-sdk": "npm:^1.10.0"
-    "@spotify-confidence/openfeature-server-provider": "npm:0.2.1"
+    "@spotify-confidence/openfeature-server-provider": "npm:0.3.0-rc.0"
   languageName: unknown
   linkType: soft
 
@@ -16606,8 +16606,8 @@ __metadata:
     "@babel/plugin-transform-react-jsx": "npm:^7.22.15"
     "@openfeature/core": "npm:^0.0.24"
     "@openfeature/web-sdk": "npm:^0.4.11"
-    "@spotify-confidence/integration-react": "npm:0.2.1"
-    "@spotify-confidence/openfeature-web-provider": "npm:0.2.1"
+    "@spotify-confidence/integration-react": "npm:0.3.0-rc.0"
+    "@spotify-confidence/openfeature-web-provider": "npm:0.3.0-rc.0"
     "@testing-library/dom": "npm:^7.29.6"
     "@testing-library/jest-dom": "npm:^5.14.1"
     "@testing-library/react": "npm:^13.0.0"


### PR DESCRIPTION
As a temporary workaround for limitations in Release-Please, we will allow `yarn build` in the publish step to modify the lock-file. 

## Hi There, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
