### PR TITLE
ci: amend releases

### DIFF
--- a/.github/workflows/Amend-Release.yml
+++ b/.github/workflows/Amend-Release.yml
@@ -1,0 +1,39 @@
+name: Amend Release with yarn.lock update
+
+on:
+  push:
+    branches:
+      - 'release-please**'
+
+jobs:
+  Amend-Release:
+    strategy:
+      matrix:
+        node-version: [18.x]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          scope: '@spotify-confidence'
+      - name: Install dependencies
+        shell: bash
+        run: corepack enable && yarn install
+      - name: Run yarn build
+        shell: bash
+        run: yarn build
+      - name: Commit and push changes
+        run: |
+          git status && \
+          git --no-pager diff && \
+          git config user.name "confidence-bot" && \
+          git config user.email "confidence+bot@spotify.com" && \
+          git add yarn.lock && \
+          git commit -m "chore: auto update yarn.lock" && \
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Amend-Release.yml
+++ b/.github/workflows/Amend-Release.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: corepack enable && yarn install
-      - name: Run yarn build
-        shell: bash
-        run: yarn build
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: Commit and push changes

--- a/.github/workflows/Amend-Release.yml
+++ b/.github/workflows/Amend-Release.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Run yarn build
         shell: bash
         run: yarn build
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: Commit and push changes
         run: |
           git status && \


### PR DESCRIPTION
The idea with this workflow is to run on top of every release-please PR and amend it by running `yarn build`, generating potential changes to the `yarn.lock` file. 

Right now I don't know if this will actually be triggered since the Release-please workflow is run by a bot and any actions done by it will not trigger other (this) workflows. (As per [this](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow))

> If you do want to trigger a workflow from within a workflow run, you can use a GitHub App installation access token or a personal access token instead of GITHUB_TOKEN to trigger events that require a token.

