### PR TITLE
fix: return the prev assigned value while provider is stale

### DIFF
--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.test.ts
@@ -153,14 +153,14 @@ describe('ConfidenceProvider', () => {
       expect(resolveMock).not.toHaveBeenCalled();
     });
 
-    it('should return default with reason stale during fetch', async () => {
+    it('should return previously assigned with reason stale during fetch', async () => {
       await instanceUnderTest.initialize({ targetingKey: 'A' });
 
       expect(
         instanceUnderTest.resolveBooleanEvaluation('testFlag.bool', false, { targetingKey: 'B' }, dummyConsole),
       ).toEqual(
         expect.objectContaining({
-          value: false,
+          value: true,
           reason: 'STALE',
         }),
       );

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -95,13 +95,6 @@ export class ConfidenceWebProvider implements Provider {
       };
     }
 
-    if (!equal(this.flagResolution.context, this.convertContext(context))) {
-      return {
-        value: defaultValue,
-        reason: 'STALE',
-      };
-    }
-
     const [flagName, ...pathParts] = flagKey.split('.');
 
     try {
@@ -158,9 +151,15 @@ export class ConfidenceWebProvider implements Provider {
         this.confidence.apply(this.flagResolution.resolveToken, flagName);
       }
       logger.info('Value for "%s" successfully evaluated', flagKey);
+      const currContext: any = this.convertContext(context);
+      const cachedContext: any = this.flagResolution.context;
+      const reason = Object.keys(currContext).some(key => !equal(currContext[key], cachedContext[key]))
+        ? 'STALE'
+        : mapConfidenceReason(flag.reason);
+
       return {
         value: flagValue.value as T,
-        reason: mapConfidenceReason(flag.reason),
+        reason: reason,
         variant: flag.variant,
         flagMetadata: {
           resolveToken: this.flagResolution.resolveToken,


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing
- [ ] Relevant documentation updated
- [ ] linter/style run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
