### PR TITLE
refactor: add message container to payload

### DIFF
--- a/packages/sdk/src/Confidence.e2e.test.ts
+++ b/packages/sdk/src/Confidence.e2e.test.ts
@@ -16,23 +16,23 @@ describe('Confidence E2E Tests', () => {
 
   describe('sendEvent', () => {
     it('should log a trace message when all events succeed', async () => {
-      confidence.sendEvent('js-sdk-e2e-test', { pants: 'blue' });
-      confidence.sendEvent('js-sdk-e2e-test', { pants: 'yellow' });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: 'blue' });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: 'yellow' });
       expect(await nextMockArgs(loggerMock.trace)).toEqual(['Confidence: successfully uploaded %i events', 2]);
     });
     it('should log a warning message when some events fail', async () => {
-      confidence.sendEvent('js-sdk-e2e-test', { pants: 'red' });
-      confidence.sendEvent('js-sdk-e2e-test', { pants: 3 });
-      confidence.sendEvent('js-sdk-e2e-test', { pants: true });
-      confidence.sendEvent('js-sdk-e2e-test', { pants: 4 });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: 'red' });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: 3 });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: true });
+      confidence.sendEvent('js-sdk-e2e-tests', { pants: 4 });
 
       expect(await nextMockArgs(loggerMock.warn)).toEqual([
         'Confidence: failed to upload %i out of %i event(s) with the following errors: %o',
         3,
         4,
         [
-          'pants: Field was expected to be of type string, was number',
-          'pants: Field was expected to be of type string, was bool',
+          'message.pants: Field was expected to be of type string, was number',
+          'message.pants: Field was expected to be of type string, was bool',
         ],
       ]);
     });

--- a/packages/sdk/src/EventSenderEngine.test.ts
+++ b/packages/sdk/src/EventSenderEngine.test.ts
@@ -40,8 +40,35 @@ describe('EventSenderEngine unit tests', () => {
     }
     expect(flushSpy).toHaveBeenCalledTimes(1);
     await jest.runAllTimersAsync();
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(flushSpy).toHaveBeenCalledTimes(2);
+  });
+  it('payload should prioritize message fields', async () => {
+    const noBatchEngine = new EventSenderEngine({
+      clientSecret: 'my_secret',
+      maxBatchSize: 1,
+      flushTimeoutMilliseconds: FLUSH_TIMEOUT,
+      fetchImplementation: mockFetch as any,
+      region: 'eu',
+      maxOpenRequests: MAX_OPEN_REQUESTS,
+      logger: {},
+    });
+    const uploadSpy = jest.spyOn(noBatchEngine, 'upload');
+    noBatchEngine.send({ a: 2, message: 3 }, 'my_event', { a: 0, message: 1 });
+    await jest.runAllTimersAsync();
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    expect(uploadSpy).toHaveBeenCalledWith({
+      sendTime: expect.any(String),
+      clientSecret: 'my_secret',
+      events: [
+        {
+          eventDefinition: 'my_event',
+          eventTime: expect.any(String),
+          payload: {
+            message: { a: 0, message: 1 },
+            a: 2,
+          },
+        },
+      ],
+    });
   });
   it('should handle a lot of events', async () => {
     const eventCount = BATCH_SIZE * MAX_OPEN_REQUESTS * 2;


### PR DESCRIPTION
Created new flag `js-sdk-e2e-tests` in the backend, due to some irreversible schema changes mistakenly added to `js-sdk-e2e-test`
