### PR TITLE
feat: default info logging to console in development

### DIFF
--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -86,7 +86,7 @@ export class ConfidenceWebProvider implements Provider {
     logger: Logger,
   ): ResolutionDetails<T> {
     if (!this.currentFlagResolution) {
-      logger.warn('Provider not ready');
+      logger.warn('Confidence: provider not ready');
       return {
         errorCode: ErrorCode.PROVIDER_NOT_READY,
         value: defaultValue,
@@ -100,7 +100,7 @@ export class ConfidenceWebProvider implements Provider {
       const flag = this.currentFlagResolution.flags[flagName];
 
       if (!flag) {
-        logger.warn('Flag "%s" was not found', flagName);
+        logger.warn('Confidence: flag "%s" was not found', flagName);
         return {
           errorCode: ErrorCode.FLAG_NOT_FOUND,
           value: defaultValue,
@@ -122,7 +122,7 @@ export class ConfidenceWebProvider implements Provider {
       try {
         flagValue = FlagResolution.FlagValue.traverse(flag, pathParts.join('.'));
       } catch (e) {
-        logger.warn('Value with path "%s" was not found in flag "%s"', pathParts.join('.'), flagName);
+        logger.warn('Confidence: value with path "%s" was not found in flag "%s"', pathParts.join('.'), flagName);
         return {
           errorCode: ErrorCode.PARSE_ERROR,
           value: defaultValue,
@@ -138,7 +138,7 @@ export class ConfidenceWebProvider implements Provider {
       }
 
       if (!FlagResolution.FlagValue.matches(flagValue, defaultValue)) {
-        logger.warn('Value for "%s" is of incorrect type', flagKey);
+        logger.warn('Confidence: value for "%s" is of incorrect type', flagKey);
         return {
           errorCode: ErrorCode.TYPE_MISMATCH,
           value: defaultValue,
@@ -149,7 +149,7 @@ export class ConfidenceWebProvider implements Provider {
       if (this.confidence.environment === 'client') {
         this.confidence.apply(this.currentFlagResolution.resolveToken, flagName);
       }
-      logger.info('Value for "%s" successfully evaluated', flagKey);
+      logger.info('Confidence: value for "%s" successfully evaluated', flagKey);
       const reason = this.pendingFlagResolution ? 'STALE' : mapConfidenceReason(flag.reason);
 
       return {
@@ -161,7 +161,7 @@ export class ConfidenceWebProvider implements Provider {
         },
       };
     } catch (e: unknown) {
-      logger.warn('Error %o occurred in flag evaluation', e);
+      logger.warn('Confidence: error %o occurred in flag evaluation', e);
       return {
         errorCode: ErrorCode.GENERAL,
         value: defaultValue,

--- a/packages/sdk/src/Confidence.e2e.test.ts
+++ b/packages/sdk/src/Confidence.e2e.test.ts
@@ -2,7 +2,7 @@ import { Confidence } from './Confidence';
 
 describe('Confidence E2E Tests', () => {
   const loggerMock = {
-    trace: jest.fn(),
+    info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
   };
@@ -18,7 +18,7 @@ describe('Confidence E2E Tests', () => {
     it('should log a trace message when all events succeed', async () => {
       confidence.track('js-sdk-e2e-tests', { pants: 'blue' });
       confidence.track('js-sdk-e2e-tests', { pants: 'yellow' });
-      expect(await nextMockArgs(loggerMock.trace)).toEqual(['Confidence: successfully uploaded %i events', 2]);
+      expect(await nextMockArgs(loggerMock.info)).toEqual(['Confidence: successfully uploaded %i events', 2]);
     });
     it('should log a warning message when some events fail', async () => {
       confidence.track('js-sdk-e2e-tests', { pants: 'red' });

--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -109,10 +109,10 @@ export class EventSenderEngine {
     })
       .then(errors => {
         if (errors.length === 0) {
-          this.logger.trace?.('Confidence: successfully uploaded %i events', batchSize);
+          this.logger.info?.('Confidence: successfully uploaded %i events', batchSize);
           return true;
         }
-        const distinctErrorMessages = Array.from(new Set(errors.map(({ message }) => message)));
+        const distinctErrorMessages = Array.from(new Set(errors.map(({ reason, message }) => message || reason)));
         this.logger.warn?.(
           'Confidence: failed to upload %i out of %i event(s) with the following errors: %o',
           errors.length,

--- a/packages/sdk/src/logger.ts
+++ b/packages/sdk/src/logger.ts
@@ -1,7 +1,7 @@
 export namespace Logger {
   type Mutable<T> = { -readonly [P in keyof T]: T[P] };
   const NOOP_LOGGER = Object.freeze({});
-  const LEVELS = ['trace', 'debug', 'warn', 'error'] as const;
+  const LEVELS = ['trace', 'debug', 'info', 'warn', 'error'] as const;
   export type Fn = (message: string, ...optionalParams: any[]) => void;
   export type Level = (typeof LEVELS)[number];
 
@@ -20,6 +20,7 @@ export namespace Logger {
 export interface Logger {
   readonly trace?: Logger.Fn;
   readonly debug?: Logger.Fn;
+  readonly info?: Logger.Fn;
   readonly warn?: Logger.Fn;
   readonly error?: Logger.Fn;
 }

--- a/packages/sdk/src/trackers/pageViews.ts
+++ b/packages/sdk/src/trackers/pageViews.ts
@@ -42,7 +42,7 @@ export function pageViews(): Trackable.Manager {
           url: location.href,
         },
       });
-      controller.config.logger.debug?.('page viewed', { type });
+      controller.config.logger.debug?.('Confidence: page viewed', { type });
       controller.track('page-viewed');
 
       referrer = location.href;


### PR DESCRIPTION
Use the console as a default alternative for development mode apps. Will log at info level.