### PR TITLE
fix: only emit resolve helper log once per flag+context

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -13,6 +13,8 @@ export interface CacheOptions {
     //
     // @internal (undocumented)
     entries?: AsyncIterable<CacheEntry>;
+    // @internal
+    loggedFlags?: Set<string>;
     scope?: CacheScope;
 }
 

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -329,11 +329,15 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   }
 
   private showLoggerLink(flag: string, context: Context) {
-    this.config.logger.info?.(
-      `See resolves for '${flag}' in Confidence: https://app.confidence.spotify.com/flags/resolver-test?client-key=${
-        this.config.clientSecret
-      }&flag=flags/${flag}&context=${encodeURIComponent(JSON.stringify(context))}`,
-    );
+    const logKey = `${flag}:${Value.serialize(context)}`;
+    if (!this.config.cache?.loggedFlags?.has(logKey)) {
+      this.config.cache?.loggedFlags?.add(logKey);
+      this.config.logger.info?.(
+        `See resolves for '${flag}' in Confidence: https://app.confidence.spotify.com/flags/resolver-test?client-key=${
+          this.config.clientSecret
+        }&flag=flags/${flag}&context=${encodeURIComponent(JSON.stringify(context))}`,
+      );
+    }
   }
 
   toOptions(): ConfidenceOptions {
@@ -371,7 +375,9 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       disableTelemetry = false,
       applyDebounce = 10,
       waitUntil,
-      cache = {},
+      cache = {
+        loggedFlags: new Set(),
+      },
     } = options;
     if (environment !== 'client' && environment !== 'backend') {
       throw new Error(`Invalid environment: ${environment}. Must be 'client' or 'backend'.`);


### PR DESCRIPTION
quick fix to get the logging for hinting about the resolve tester to be less spammy.