### PR TITLE
test: add integration test for integer flag resolution

### DIFF
--- a/packages/sdk/src/Confidence.int.test.ts
+++ b/packages/sdk/src/Confidence.int.test.ts
@@ -129,6 +129,32 @@ describe('Confidence integration tests', () => {
     expect(await confidence.getFlag('flag2.str', 'goodbye')).toBe('hello again');
     expect(applyHandlerMock).not.toHaveBeenCalled();
   });
+  it('should resolve an integer value from a flag with intSchema', async () => {
+    resolveHandlerMock.mockReturnValue({
+      resolvedFlags: [
+        {
+          flag: 'flags/test-flag',
+          variant: 'flags/test-flag/variants/variant-1',
+          value: {
+            myinteger: 400.0,
+          },
+          flagSchema: {
+            schema: {
+              myinteger: {
+                intSchema: {},
+              },
+            },
+          },
+          reason: 'RESOLVE_REASON_MATCH',
+          shouldApply: true,
+        },
+      ],
+      resolveToken: 'token1',
+    });
+
+    expect(await confidence.getFlag('test-flag.myinteger', 0)).toBe(400);
+  });
+
   it('should send evaluation trace with TARGETING_MATCH reason on successful evaluation', async () => {
     await confidence.getFlag('flag1.str', 'goodbye');
     // trigger a new resolve by changing context


### PR DESCRIPTION
## Summary
- Adds an integration test verifying the SDK correctly resolves an integer flag value from a resolve response with `intSchema`

## Test plan
- [x] New test passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)