### PR TITLE
fix: align evaluation trace mappings with Swift and Java SDKs

### DIFF
--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -34,11 +34,13 @@ export function createConfidenceServerProvider(
   confidenceOrOptions: Confidence | ConfidenceProviderFactoryOptions,
 ): Provider {
   if (confidenceOrOptions instanceof Confidence) {
+    confidenceOrOptions.setTelemetryLibraryOpenFeature();
     return new ConfidenceServerProvider(confidenceOrOptions);
   }
   const confidence = Confidence.create({
     ...confidenceOrOptions,
     environment: 'backend',
   });
+  confidence.setTelemetryLibraryOpenFeature();
   return new ConfidenceServerProvider(confidence);
 }

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -32,11 +32,13 @@ export function createConfidenceWebProvider(confidence: Confidence): Provider;
  * @public */
 export function createConfidenceWebProvider(confidenceOrOptions: Confidence | ConfidenceWebProviderOptions): Provider {
   if (confidenceOrOptions instanceof Confidence) {
+    confidenceOrOptions.setTelemetryLibraryOpenFeature();
     return new ConfidenceWebProvider(confidenceOrOptions);
   }
   const confidence = Confidence.create({
     ...confidenceOrOptions,
     environment: 'client',
   });
+  confidence.setTelemetryLibraryOpenFeature();
   return new ConfidenceWebProvider(confidence);
 }

--- a/packages/sdk/proto/confidence/telemetry/v1/telemetry.proto
+++ b/packages/sdk/proto/confidence/telemetry/v1/telemetry.proto
@@ -22,7 +22,7 @@ message LibraryTraces {
     TraceId id = 1;
 
     oneof traceData {
-      uint64 millisecond_duration = 2;
+      uint64 millisecond_duration = 2 [deprecated = true];
       RequestTrace request_trace = 3;
       CountTrace count_trace = 4;
       EvaluationTrace evaluation_trace = 5;

--- a/packages/sdk/src/Confidence.int.test.ts
+++ b/packages/sdk/src/Confidence.int.test.ts
@@ -1,6 +1,7 @@
 import { Confidence } from './Confidence';
 import { abortableSleep } from './fetch-util';
 import {
+  LibraryTraces_Library,
   LibraryTraces_Trace_EvaluationTrace_EvaluationErrorCode,
   LibraryTraces_Trace_EvaluationTrace_EvaluationReason,
   LibraryTraces_TraceId,
@@ -224,6 +225,140 @@ describe('Confidence integration tests', () => {
         }),
       ]),
     );
+  });
+
+  it('should send evaluation trace with DISABLED reason for archived flags', async () => {
+    const archivedResponse = {
+      resolvedFlags: [
+        {
+          flag: 'flags/flag1',
+          variant: '',
+          value: {},
+          flagSchema: { schema: { str: { stringSchema: {} } } },
+          reason: 'RESOLVE_REASON_FLAG_ARCHIVED',
+          shouldApply: false,
+        },
+      ],
+      resolveToken: 'xyz',
+    };
+    resolveHandlerMock.mockReturnValue(archivedResponse);
+    await confidence.getFlag('flag1.str', 'goodbye');
+    // trigger a new resolve to flush telemetry
+    confidence.setContext({ pants: 'yellow' });
+    await confidence.getFlag('flag1.str', 'goodbye');
+
+    const telemetry = decodeTelemetryHeader(capturedResolveRequests[1]);
+    expect(telemetry).toBeDefined();
+    const evaluationTraces = telemetry!.libraryTraces.find(lt =>
+      lt.traces.some(t => t.id === LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION),
+    );
+    expect(evaluationTraces).toBeDefined();
+    expect(evaluationTraces!.traces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION,
+          evaluationTrace: {
+            reason: LibraryTraces_Trace_EvaluationTrace_EvaluationReason.EVALUATION_REASON_DISABLED,
+            errorCode: LibraryTraces_Trace_EvaluationTrace_EvaluationErrorCode.EVALUATION_ERROR_CODE_UNSPECIFIED,
+          },
+        }),
+      ]),
+    );
+  });
+
+  it('should send evaluation trace with TARGETING_KEY_MISSING for targeting key errors', async () => {
+    const targetingKeyErrorResponse = {
+      resolvedFlags: [
+        {
+          flag: 'flags/flag1',
+          variant: '',
+          value: {},
+          flagSchema: { schema: { str: { stringSchema: {} } } },
+          reason: 'RESOLVE_REASON_TARGETING_KEY_ERROR',
+          shouldApply: false,
+        },
+      ],
+      resolveToken: 'xyz',
+    };
+    resolveHandlerMock.mockReturnValue(targetingKeyErrorResponse);
+    await confidence.getFlag('flag1.str', 'goodbye');
+    // trigger a new resolve to flush telemetry
+    confidence.setContext({ pants: 'yellow' });
+    await confidence.getFlag('flag1.str', 'goodbye');
+
+    const telemetry = decodeTelemetryHeader(capturedResolveRequests[1]);
+    expect(telemetry).toBeDefined();
+    const evaluationTraces = telemetry!.libraryTraces.find(lt =>
+      lt.traces.some(t => t.id === LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION),
+    );
+    expect(evaluationTraces).toBeDefined();
+    expect(evaluationTraces!.traces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION,
+          evaluationTrace: {
+            reason: LibraryTraces_Trace_EvaluationTrace_EvaluationReason.EVALUATION_REASON_ERROR,
+            errorCode:
+              LibraryTraces_Trace_EvaluationTrace_EvaluationErrorCode.EVALUATION_ERROR_CODE_TARGETING_KEY_MISSING,
+          },
+        }),
+      ]),
+    );
+  });
+
+  it('should send evaluation trace with DEFAULT reason for no-segment-match', async () => {
+    const noSegmentMatchResponse = {
+      resolvedFlags: [
+        {
+          flag: 'flags/flag1',
+          variant: '',
+          value: {},
+          flagSchema: { schema: { str: { stringSchema: {} } } },
+          reason: 'RESOLVE_REASON_NO_SEGMENT_MATCH',
+          shouldApply: false,
+        },
+      ],
+      resolveToken: 'xyz',
+    };
+    resolveHandlerMock.mockReturnValue(noSegmentMatchResponse);
+    await confidence.getFlag('flag1.str', 'goodbye');
+    // trigger a new resolve to flush telemetry
+    confidence.setContext({ pants: 'yellow' });
+    await confidence.getFlag('flag1.str', 'goodbye');
+
+    const telemetry = decodeTelemetryHeader(capturedResolveRequests[1]);
+    expect(telemetry).toBeDefined();
+    const evaluationTraces = telemetry!.libraryTraces.find(lt =>
+      lt.traces.some(t => t.id === LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION),
+    );
+    expect(evaluationTraces).toBeDefined();
+    expect(evaluationTraces!.traces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION,
+          evaluationTrace: {
+            reason: LibraryTraces_Trace_EvaluationTrace_EvaluationReason.EVALUATION_REASON_DEFAULT,
+            errorCode: LibraryTraces_Trace_EvaluationTrace_EvaluationErrorCode.EVALUATION_ERROR_CODE_UNSPECIFIED,
+          },
+        }),
+      ]),
+    );
+  });
+
+  it('should tag telemetry as LIBRARY_OPEN_FEATURE when setTelemetryLibraryOpenFeature is called', async () => {
+    confidence.setTelemetryLibraryOpenFeature();
+    await confidence.getFlag('flag1.str', 'goodbye');
+    // trigger a new resolve to flush telemetry
+    confidence.setContext({ pants: 'yellow' });
+    await confidence.getFlag('flag1.str', 'goodbye');
+
+    const telemetry = decodeTelemetryHeader(capturedResolveRequests[1]);
+    expect(telemetry).toBeDefined();
+    const evaluationTraces = telemetry!.libraryTraces.find(lt =>
+      lt.traces.some(t => t.id === LibraryTraces_TraceId.TRACE_ID_FLAG_EVALUATION),
+    );
+    expect(evaluationTraces).toBeDefined();
+    expect(evaluationTraces!.library).toBe(LibraryTraces_Library.LIBRARY_OPEN_FEATURE);
   });
 
   it('should abort previous requests when context changes', async () => {

--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -5,6 +5,7 @@ import { EventSenderEngine } from './EventSenderEngine';
 import { FlagResolution } from './FlagResolution';
 import { FlagResolverClient, PendingResolution } from './FlagResolverClient';
 import { FlagEvaluation, State, StateObserver } from './flags';
+import { Telemetry } from './Telemetry';
 
 const flagResolverClientMock: jest.Mocked<FlagResolverClient> = {
   resolve: jest.fn(),
@@ -34,6 +35,7 @@ describe('Confidence', () => {
       },
       staleFlagTraceConsumer: jest.fn(),
       emitEvaluationTrace: jest.fn(),
+      telemetry: new Telemetry({ disabled: true, environment: 'client' }),
     });
     flagResolverClientMock.resolve.mockImplementation((context, _flags) => {
       const flagResolution = new Promise<FlagResolution>(resolve => {

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -84,6 +84,8 @@ export interface Configuration extends ConfidenceOptions {
   readonly staleFlagTraceConsumer: TraceConsumer;
   /** @internal */
   readonly emitEvaluationTrace: (trace: EvaluationTrace) => void;
+  /** @internal */
+  readonly telemetry: Telemetry;
 }
 
 /**
@@ -378,6 +380,14 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
   }
 
   /**
+   * Tags all telemetry from this instance as originating from the OpenFeature library.
+   * Called by OpenFeature providers during initialization.
+   */
+  setTelemetryLibraryOpenFeature(): void {
+    this.config.telemetry.setLibrary(LibraryTraces_Library.LIBRARY_OPEN_FEATURE);
+  }
+
+  /**
    * Creates a Confidence instance
    * @param clientSecret - clientSecret found on the Confidence console
    * @param region - region in which Confidence will operate
@@ -476,6 +486,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       cacheProvider,
       staleFlagTraceConsumer,
       emitEvaluationTrace,
+      telemetry,
     });
   }
 }
@@ -493,34 +504,33 @@ function evaluationTraceFromResult(evaluation: FlagEvaluation.Resolved<Value>): 
   const EvalReason = LibraryTraces_Trace_EvaluationTrace_EvaluationReason;
   const EvalError = LibraryTraces_Trace_EvaluationTrace_EvaluationErrorCode;
 
-  if (evaluation.reason === 'MATCH') {
-    return {
-      reason: EvalReason.EVALUATION_REASON_TARGETING_MATCH,
-      errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED,
-    };
+  switch (evaluation.reason) {
+    case 'MATCH':
+      return { reason: EvalReason.EVALUATION_REASON_TARGETING_MATCH, errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED };
+    case 'NO_SEGMENT_MATCH':
+    case 'NO_TREATMENT_MATCH':
+      return { reason: EvalReason.EVALUATION_REASON_DEFAULT, errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED };
+    case 'FLAG_ARCHIVED':
+      return { reason: EvalReason.EVALUATION_REASON_DISABLED, errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED };
+    case 'TARGETING_KEY_ERROR':
+      return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_TARGETING_KEY_MISSING };
+    case 'ERROR':
+      switch (evaluation.errorCode) {
+        case 'FLAG_NOT_FOUND':
+          return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_FLAG_NOT_FOUND };
+        case 'TYPE_MISMATCH':
+          return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_TYPE_MISMATCH };
+        case 'NOT_READY':
+          return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_PROVIDER_NOT_READY };
+        case 'GENERAL':
+        case 'TIMEOUT':
+        default:
+          return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_GENERAL };
+      }
+    case 'UNSPECIFIED':
+    default:
+      return { reason: EvalReason.EVALUATION_REASON_UNSPECIFIED, errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED };
   }
-  if (evaluation.reason === 'ERROR') {
-    switch (evaluation.errorCode) {
-      case 'FLAG_NOT_FOUND':
-        return {
-          reason: EvalReason.EVALUATION_REASON_ERROR,
-          errorCode: EvalError.EVALUATION_ERROR_CODE_FLAG_NOT_FOUND,
-        };
-      case 'TYPE_MISMATCH':
-        return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_TYPE_MISMATCH };
-      case 'NOT_READY':
-        return {
-          reason: EvalReason.EVALUATION_REASON_ERROR,
-          errorCode: EvalError.EVALUATION_ERROR_CODE_PROVIDER_NOT_READY,
-        };
-      case 'GENERAL':
-      case 'TIMEOUT':
-        return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_GENERAL };
-      default:
-        return { reason: EvalReason.EVALUATION_REASON_ERROR, errorCode: EvalError.EVALUATION_ERROR_CODE_GENERAL };
-    }
-  }
-  return { reason: EvalReason.EVALUATION_REASON_DEFAULT, errorCode: EvalError.EVALUATION_ERROR_CODE_UNSPECIFIED };
 }
 
 function defaultLogger(): Logger {

--- a/packages/sdk/src/Telemetry.ts
+++ b/packages/sdk/src/Telemetry.ts
@@ -22,11 +22,16 @@ export class Telemetry {
   private readonly logger?: Logger;
   private readonly libraryTraces: LibraryTraces[] = [];
   private readonly platform: Platform;
+  private library: LibraryTraces_Library = LibraryTraces_Library.LIBRARY_CONFIDENCE;
 
   constructor(opts: TelemetryOptions) {
     this.disabled = opts.disabled;
     this.logger = opts.logger;
     this.platform = opts.environment === 'client' ? Platform.PLATFORM_JS_WEB : Platform.PLATFORM_JS_SERVER;
+  }
+
+  setLibrary(library: LibraryTraces_Library): void {
+    this.library = library;
   }
 
   public registerLibraryTraces({ library, version, id }: Tag): TraceConsumer {
@@ -49,10 +54,11 @@ export class Telemetry {
   }
 
   getSnapshot(): Monitoring {
+    const currentLibrary = this.library;
     const libraryTraces = this.libraryTraces
       .filter(({ traces }) => traces.length > 0)
-      .map(({ library, libraryVersion, traces }) => ({
-        library,
+      .map(({ libraryVersion, traces }) => ({
+        library: currentLibrary,
         libraryVersion,
         traces: traces.splice(0, traces.length),
       }));


### PR DESCRIPTION
## Summary

Fixes several telemetry misalignments found when reviewing the evaluation trace implementation against the backend proto and the Swift/Java SDK implementations:

- **`FLAG_ARCHIVED` → `EVALUATION_REASON_DISABLED`**: Was incorrectly mapped to `DEFAULT`. Aligned with Swift (`case .archived: return (.disabled, .unspecified)`) and Java (`RESOLVE_REASON_FLAG_ARCHIVED → EVALUATION_REASON_DISABLED`).
- **`TARGETING_KEY_ERROR` → `ERROR` + `TARGETING_KEY_MISSING`**: Was falling through to `DEFAULT`. Aligned with Swift (`case .targetingKeyError: return (.error, .targetingKeyMissing)`) and Java (`RESOLVE_REASON_TARGETING_KEY_ERROR → EVALUATION_ERROR_CODE_TARGETING_KEY_MISSING`).
- **`UNSPECIFIED` → `EVALUATION_REASON_UNSPECIFIED`**: Default fallback was `DEFAULT` instead of `UNSPECIFIED`.
- **`LIBRARY_OPEN_FEATURE` tagging**: Added `setTelemetryLibraryOpenFeature()` to `Confidence` and wired it into both `createConfidenceWebProvider` and `createConfidenceServerProvider` factory functions. This mirrors the Swift SDK's `setTelemetryLibraryOpenFeature()` and Java SDK's `Telemetry(boolean isProvider)` patterns.
- **Proto alignment**: Marked `millisecond_duration` on `Trace.traceData` as `[deprecated = true]` to match the backend proto.

## Test plan

- [x] Added integration test: `FLAG_ARCHIVED` produces `EVALUATION_REASON_DISABLED` trace
- [x] Added integration test: `TARGETING_KEY_ERROR` produces `ERROR` + `TARGETING_KEY_MISSING` trace
- [x] Added integration test: `NO_SEGMENT_MATCH` produces `EVALUATION_REASON_DEFAULT` trace
- [x] Added integration test: `setTelemetryLibraryOpenFeature` tags traces as `LIBRARY_OPEN_FEATURE`
- [x] All 92 existing tests pass

Made with [Cursor](https://cursor.com)