### PR TITLE
fix: prevent AbortError from leaving flag state stuck in NOT_READY

### DIFF
--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
@@ -21,8 +21,8 @@ describe('ConfidenceWebProvider - AbortError recovery', () => {
   });
 
   it('initialize rejects when resolve fails and state transitions to ERROR', async () => {
-    // After fix: when a resolve fails (including AbortError), the SDK
-    // transitions to ERROR. subscribe emits NOT_READY then ERROR.
+    // when a resolve fails (including AbortError), the SDK transitions to ERROR.
+    // subscribe emits NOT_READY then ERROR.
     // expectReadyOrError() sees ERROR and rejects with an appropriate error.
     confidenceMock.subscribe.mockImplementation(observer => {
       observer!('NOT_READY');
@@ -57,7 +57,7 @@ describe('ConfidenceWebProvider - AbortError recovery', () => {
 
     // Expected: onContextChange rejects because expectReadyOrError sees ERROR
     await expect(provider.onContextChange({ targetingKey: 'test' }, { targetingKey: 'test2' })).rejects.toThrow(
-      'Provider initialization failed',
+      'Provider context change failed',
     );
     await provider.onClose();
   });

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
@@ -56,9 +56,9 @@ describe('ConfidenceWebProvider - AbortError recovery', () => {
     });
 
     // Expected: onContextChange rejects because expectReadyOrError sees ERROR
-    await expect(
-      provider.onContextChange({ targetingKey: 'test' }, { targetingKey: 'test2' }),
-    ).rejects.toThrow('Provider initialization failed');
+    await expect(provider.onContextChange({ targetingKey: 'test' }, { targetingKey: 'test2' })).rejects.toThrow(
+      'Provider initialization failed',
+    );
     await provider.onClose();
   });
 });

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.abort.test.ts
@@ -1,0 +1,64 @@
+import { ConfidenceWebProvider } from './ConfidenceWebProvider';
+import { FlagResolver } from '@spotify-confidence/sdk';
+
+function createConfidenceMock(): jest.Mocked<FlagResolver> {
+  return {
+    getContext: jest.fn(),
+    setContext: jest.fn(),
+    withContext: jest.fn(),
+    clearContext: jest.fn(),
+    subscribe: jest.fn(),
+    evaluateFlag: jest.fn(),
+    getFlag: jest.fn(),
+  };
+}
+
+describe('ConfidenceWebProvider - AbortError recovery', () => {
+  let confidenceMock: jest.Mocked<FlagResolver>;
+
+  beforeEach(() => {
+    confidenceMock = createConfidenceMock();
+  });
+
+  it('initialize rejects when resolve fails and state transitions to ERROR', async () => {
+    // After fix: when a resolve fails (including AbortError), the SDK
+    // transitions to ERROR. subscribe emits NOT_READY then ERROR.
+    // expectReadyOrError() sees ERROR and rejects with an appropriate error.
+    confidenceMock.subscribe.mockImplementation(observer => {
+      observer!('NOT_READY');
+      setTimeout(() => observer!('ERROR'), 10);
+      return jest.fn();
+    });
+
+    const provider = new ConfidenceWebProvider(confidenceMock);
+
+    // Expected: initialize rejects because expectReadyOrError sees ERROR
+    await expect(provider.initialize({ targetingKey: 'test' })).rejects.toThrow('Provider initialization failed');
+    await provider.onClose();
+  });
+
+  it('onContextChange rejects when resolve fails after context change', async () => {
+    // Step 1: Initialize succeeds normally
+    confidenceMock.subscribe.mockImplementation(observer => {
+      observer!('READY');
+      return jest.fn();
+    });
+
+    const provider = new ConfidenceWebProvider(confidenceMock);
+    await provider.initialize({ targetingKey: 'test' });
+
+    // Step 2: After context change, resolve fails and SDK transitions
+    // through STALE to ERROR. expectReadyOrError() sees ERROR and rejects.
+    confidenceMock.subscribe.mockImplementation(observer => {
+      observer!('STALE');
+      setTimeout(() => observer!('ERROR'), 10);
+      return jest.fn();
+    });
+
+    // Expected: onContextChange rejects because expectReadyOrError sees ERROR
+    await expect(
+      provider.onContextChange({ targetingKey: 'test' }, { targetingKey: 'test2' }),
+    ).rejects.toThrow('Provider initialization failed');
+    await provider.onClose();
+  });
+});

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.ts
@@ -66,17 +66,21 @@ export class ConfidenceWebProvider implements Provider {
       return Promise.resolve();
     }
     this.confidence.setContext(convertContext(changes));
-    return this.expectReadyOrError();
+    return this.expectReadyOrError(true);
   }
 
-  private expectReadyOrError(): Promise<void> {
+  private expectReadyOrError(isContextChange: boolean = false): Promise<void> {
     let close: () => void;
     return new Promise<void>((resolve, reject) => {
       close = this.confidence.subscribe(state => {
         if (state === 'READY') {
           resolve();
         } else if (state === 'ERROR') {
-          reject(new Error('Provider initialization failed'));
+          if (isContextChange) {
+            reject(new Error('Provider context change failed'));
+          } else {
+            reject(new Error('Provider initialization failed'));
+          }
         }
       });
     }).finally(close!);

--- a/packages/sdk/src/Confidence.abort.test.ts
+++ b/packages/sdk/src/Confidence.abort.test.ts
@@ -16,7 +16,7 @@ function createAbortError(): Error {
   return error;
 }
 
-describe('Confidence - AbortError state machine bugs', () => {
+describe('Confidence - AbortError state machine', () => {
   let confidence: Confidence;
 
   beforeEach(() => {
@@ -120,9 +120,9 @@ describe('Confidence - AbortError state machine bugs', () => {
 
   describe('AbortError should transition to ERROR', () => {
     it('should transition to ERROR when resolve rejects with AbortError', async () => {
-      // When a resolve rejects with AbortError, the catch block in
-      // Confidence.ts:262-267 should set currentFlags to a failed resolution
-      // so that flagState transitions to ERROR and subscribers are notified.
+      // When a resolve rejects with AbortError, the catch block should
+      // set currentFlags to a failed resolution so that flagState transitions
+      // to ERROR and subscribers are notified.
       flagResolverClientMock.resolve.mockImplementation(context => {
         return PendingResolution.create(context, () => {
           return Promise.reject(createAbortError());
@@ -136,7 +136,7 @@ describe('Confidence - AbortError state machine bugs', () => {
       await new Promise(r => setTimeout(r, 50));
 
       // Expected: state should transition from NOT_READY to ERROR
-      expect(states).toContain('ERROR');
+      expect(states).toEqual(['NOT_READY', 'ERROR']);
       close();
     });
 
@@ -154,13 +154,14 @@ describe('Confidence - AbortError state machine bugs', () => {
 
       // Each setContext triggers a new resolve (also immediately fails)
       confidence.setContext({ user: '1' });
+      // Stale
       confidence.setContext({ user: '2' });
 
       // Wait for all resolve chains to settle
       await new Promise(r => setTimeout(r, 200));
 
       // Expected: state should eventually reach ERROR
-      expect(states).toContain('ERROR');
+      expect(states).toEqual(['NOT_READY', 'STALE', 'ERROR']);
       close();
     });
 

--- a/packages/sdk/src/Confidence.abort.test.ts
+++ b/packages/sdk/src/Confidence.abort.test.ts
@@ -1,0 +1,210 @@
+import { Confidence } from './Confidence';
+import { EventSenderEngine } from './EventSenderEngine';
+import { FlagResolution } from './FlagResolution';
+import { FlagResolverClient, PendingResolution } from './FlagResolverClient';
+import { State } from './flags';
+
+const flagResolverClientMock: jest.Mocked<FlagResolverClient> = {
+  resolve: jest.fn(),
+};
+
+const eventSenderEngineMock: jest.Mocked<EventSenderEngine> = {} as any;
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.');
+  error.name = 'AbortError';
+  return error;
+}
+
+describe('Confidence - AbortError state machine bugs', () => {
+  let confidence: Confidence;
+
+  beforeEach(() => {
+    confidence = new Confidence({
+      clientSecret: 'secret',
+      timeout: 10,
+      environment: 'client',
+      logger: {},
+      eventSenderEngine: eventSenderEngineMock,
+      flagResolverClient: flagResolverClientMock,
+      cacheProvider: () => {
+        throw new Error('Not implemented');
+      },
+      staleFlagTraceConsumer: jest.fn(),
+      emitEvaluationTrace: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    flagResolverClientMock.resolve.mockReset();
+  });
+
+  describe('happy path: context change during resolve', () => {
+    it('should reach READY when second resolve succeeds after first is aborted', async () => {
+      const resolvers: Array<{
+        resolve: (v: FlagResolution) => void;
+        reject: (r: any) => void;
+      }> = [];
+
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        // Pass actual context so resolveFlags() context-equality check works
+        return PendingResolution.create(context, signal => {
+          return new Promise<FlagResolution>((resolve, reject) => {
+            resolvers.push({ resolve, reject });
+            signal.addEventListener('abort', () => reject(createAbortError()));
+          });
+        });
+      });
+
+      const states: State[] = [];
+      const close = confidence.subscribe(state => states.push(state));
+
+      expect(states).toEqual(['NOT_READY']);
+      expect(resolvers).toHaveLength(1);
+
+      // Context change aborts first resolve, starts second
+      confidence.setContext({ user: 'a' });
+      expect(resolvers).toHaveLength(2);
+
+      // Second resolve succeeds
+      resolvers[1].resolve({
+        state: 'READY',
+        context: { user: 'a' },
+        evaluate: jest.fn(),
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(states).toContain('READY');
+      close();
+    });
+
+    it('should reach READY after rapid context changes when last resolve succeeds', async () => {
+      const resolvers: Array<{
+        resolve: (v: FlagResolution) => void;
+        reject: (r: any) => void;
+        context: any;
+      }> = [];
+
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        return PendingResolution.create(context, signal => {
+          return new Promise<FlagResolution>((resolve, reject) => {
+            resolvers.push({ resolve, reject, context });
+            signal.addEventListener('abort', () => reject(createAbortError()));
+          });
+        });
+      });
+
+      const states: State[] = [];
+      const close = confidence.subscribe(state => states.push(state));
+
+      // Rapid context changes - each aborts the previous resolve
+      confidence.setContext({ user: '1' });
+      confidence.setContext({ user: '2' });
+
+      // Wait for aborted resolve chains to settle
+      await new Promise(r => setTimeout(r, 50));
+
+      // Resolve the last pending resolve
+      const last = resolvers[resolvers.length - 1];
+      last.resolve({
+        state: 'READY',
+        context: last.context,
+        evaluate: jest.fn(),
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(states).toContain('READY');
+      close();
+    });
+  });
+
+  describe('AbortError should transition to ERROR', () => {
+    it('should transition to ERROR when resolve rejects with AbortError', async () => {
+      // When a resolve rejects with AbortError, the catch block in
+      // Confidence.ts:262-267 should set currentFlags to a failed resolution
+      // so that flagState transitions to ERROR and subscribers are notified.
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        return PendingResolution.create(context, () => {
+          return Promise.reject(createAbortError());
+        });
+      });
+
+      const states: State[] = [];
+      const close = confidence.subscribe(state => states.push(state));
+
+      // Wait for promise chains to settle
+      await new Promise(r => setTimeout(r, 50));
+
+      // Expected: state should transition from NOT_READY to ERROR
+      expect(states).toContain('ERROR');
+      close();
+    });
+
+    it('should transition to ERROR after rapid context changes when all resolves fail', async () => {
+      // Every resolve rejects with AbortError immediately.
+      // After all promise chains settle, state should reach ERROR.
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        return PendingResolution.create(context, () => {
+          return Promise.reject(createAbortError());
+        });
+      });
+
+      const states: State[] = [];
+      const close = confidence.subscribe(state => states.push(state));
+
+      // Each setContext triggers a new resolve (also immediately fails)
+      confidence.setContext({ user: '1' });
+      confidence.setContext({ user: '2' });
+
+      // Wait for all resolve chains to settle
+      await new Promise(r => setTimeout(r, 200));
+
+      // Expected: state should eventually reach ERROR
+      expect(states).toContain('ERROR');
+      close();
+    });
+
+    it('should notify subscriber of ERROR state after AbortError', async () => {
+      // After a resolve fails with AbortError, the subscriber should
+      // be notified of the ERROR state. changeObserver should see the
+      // transition from NOT_READY to ERROR (different values → not deduped).
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        return PendingResolution.create(context, () => {
+          return Promise.reject(createAbortError());
+        });
+      });
+
+      const observer = jest.fn();
+      const close = confidence.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // Expected: observer called twice — first NOT_READY, then ERROR
+      expect(observer).toHaveBeenCalledTimes(2);
+      expect(observer).toHaveBeenNthCalledWith(1, 'NOT_READY');
+      expect(observer).toHaveBeenNthCalledWith(2, 'ERROR');
+      close();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('unsubscribe during initial resolve fires abort signal', () => {
+      let abortFired = false;
+
+      flagResolverClientMock.resolve.mockImplementation(context => {
+        return PendingResolution.create(context, signal => {
+          signal.addEventListener('abort', () => {
+            abortFired = true;
+          });
+          return new Promise<FlagResolution>(() => {}); // never resolves
+        });
+      });
+
+      const close = confidence.subscribe(() => {});
+
+      expect(abortFired).toBe(false);
+      close(); // unsubscribe → cleanup runs → abort pending flags
+      expect(abortFired).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -254,20 +254,19 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     const context = this.getContext();
     if (!this.pendingFlags || !Value.equal(this.pendingFlags.context, context)) {
       this.pendingFlags?.abort();
-      this.pendingFlags = this.config.flagResolverClient
-        .resolve(context, [])
+      const pending = this.config.flagResolverClient.resolve(context, []);
+      this.pendingFlags = pending
         .then(resolution => {
           this.currentFlags = resolution;
         })
         .catch(e => {
-          // TODO fix sloppy handling of error
           if (e.name !== 'AbortError') {
             this.config.logger.info?.('Resolve failed.', e);
           }
-        })
-        .finally(() => {
-          // if this resolves synchronously, the assignment on 171 will actually happen after we clear it.
-          this.pendingFlags = undefined;
+          // only set failed state if this resolve hasn't been superseded
+          if (this.pendingFlags?.signal === pending.signal) {
+            this.currentFlags = FlagResolution.failed(context, 'GENERAL', e.message || 'Resolve failed');
+          }
         });
     }
     if (this.pendingFlags.status !== 'pending') {
@@ -283,7 +282,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
    */
   get flagState(): State {
     if (this.currentFlags) {
-      if (this.pendingFlags) return 'STALE';
+      if (this.pendingFlags?.status === 'pending') return 'STALE';
       return this.currentFlags.state;
     }
     return 'NOT_READY';


### PR DESCRIPTION
## Summary
- **AbortError swallowed silently**: The `.catch()` handler in `resolveFlags()` caught AbortError but never set `currentFlags`, leaving `flagState` permanently stuck in `NOT_READY`. Subscribers (including the OpenFeature provider) were never notified.
- **`.finally()` race condition**: When a context change triggered a new resolve, the old resolve's `.finally()` cleared the new resolve's `pendingFlags` reference.
- **`flagState` getter**: Returned `STALE` for settled `pendingFlags` that lingered after `.finally()` removal. Now checks `pendingFlags?.status === 'pending'`.

## Test plan
- [x] Added `Confidence.abort.test.ts` — tests abort state machine transitions
- [x] Added `ConfidenceWebProvider.abort.test.ts` — tests OpenFeature provider integration with abort scenarios
- [x] All 176 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)