### PR TITLE
make timeout optional with default value in ConfidenceProvide

### DIFF
--- a/packages/openfeature-server-provider/src/factory.ts
+++ b/packages/openfeature-server-provider/src/factory.ts
@@ -2,14 +2,20 @@ import { Provider } from '@openfeature/server-sdk';
 import { ConfidenceServerProvider } from './ConfidenceServerProvider';
 import { Confidence } from '@spotify-confidence/sdk';
 
+// Region for Confidence API requests. 
+// Default region is used when not specified
+export type Region = 'eu' | 'us';
+
 /**
  * Factory Options for Confidence Server Provider
  * @public */
 export type ConfidenceProviderFactoryOptions = {
-  region?: 'eu' | 'us';
+  region?: Region;
   fetchImplementation?: typeof fetch;
   clientSecret: string;
-  timeout: number;
+  // Timeout for network requests in milliseconds.
+  // Defaults to an internal SDK value if not provided
+  timeout?: number;
   /** Sets an alternative resolve url */
   resolveBaseUrl?: string;
   /** Sets an alternative apply url */
@@ -37,8 +43,12 @@ export function createConfidenceServerProvider(
     // telemetry library tagging is not applied when passing a pre-built Confidence instance
     return new ConfidenceServerProvider(confidenceOrOptions);
   }
+
+  const DEFAULT_TIMEOUT = 5000;
+
   const confidence = Confidence.create({
     ...confidenceOrOptions,
+    timeout: confidenceOrOptions.timeout ?? DEFAULT_TIMEOUT,
     environment: 'backend',
     library: 'openfeature',
   });


### PR DESCRIPTION
This change introduces a default timeout value for the Confidence provider to improve usability and avoid requiring explicit configuration in simple use cases.

## What's changed:
- Timeout handling: The `timeout` field in `ConfidenceProviderFactoryOptions` is now optional. If not provided, a default value of 5000ms is used.
- Added a `DEFAULT_TIMEOUT` constant to improve clarity and maintainability.

## Notes:
This is a non-breaking change and does not affect existing behavior when timeout is explicitly provided.

All tests are passing.