### PR TITLE
fix: prevent event loss on tab close

### DIFF
--- a/packages/sdk/src/EventSenderEngine.test.ts
+++ b/packages/sdk/src/EventSenderEngine.test.ts
@@ -55,20 +55,23 @@ describe('EventSenderEngine unit tests', () => {
     noBatchEngine.send({ value: 2 }, 'my_event', { message: 1 });
     await jest.runAllTimersAsync();
     expect(uploadSpy).toHaveBeenCalledTimes(1);
-    expect(uploadSpy).toHaveBeenCalledWith({
-      sendTime: expect.any(String),
-      clientSecret: 'my_secret',
-      events: [
-        {
-          eventDefinition: 'my_event',
-          eventTime: expect.any(String),
-          payload: {
-            context: { value: 2 },
-            message: 1,
+    expect(uploadSpy).toHaveBeenCalledWith(
+      {
+        sendTime: expect.any(String),
+        clientSecret: 'my_secret',
+        events: [
+          {
+            eventDefinition: 'my_event',
+            eventTime: expect.any(String),
+            payload: {
+              context: { value: 2 },
+              message: 1,
+            },
           },
-        },
-      ],
-    });
+        ],
+      },
+      { keepalive: undefined },
+    );
   });
   it('should throw if data contains a context field', async () => {
     const noBatchEngine = new EventSenderEngine({

--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -81,7 +81,7 @@ export class EventSenderEngine {
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', () => {
         if (document.visibilityState === 'hidden') {
-          this.flush();
+          this.flush({ keepalive: true });
         }
       });
     }
@@ -108,17 +108,20 @@ export class EventSenderEngine {
     }
   }
 
-  public flush(): Promise<boolean> {
+  public flush({ keepalive }: { keepalive?: boolean } = {}): Promise<boolean> {
     this.clearPendingFlush();
     const batchSize = this.writeQueue.length;
     if (batchSize === 0) {
       return Promise.resolve(true);
     }
-    return this.upload({
-      clientSecret: this.clientSecret,
-      sendTime: new Date().toISOString(),
-      events: this.writeQueue.splice(0, this.maxBatchSize),
-    })
+    return this.upload(
+      {
+        clientSecret: this.clientSecret,
+        sendTime: new Date().toISOString(),
+        events: this.writeQueue.splice(0, this.maxBatchSize),
+      },
+      { keepalive },
+    )
       .then(errors => {
         if (errors.length === 0) {
           this.logger.info?.('Confidence: successfully uploaded %i events', batchSize);
@@ -147,7 +150,7 @@ export class EventSenderEngine {
   }
 
   // Made public for unit testing
-  public upload(batch: EventBatch): Promise<PublishError[]> {
+  public upload(batch: EventBatch, { keepalive }: { keepalive?: boolean } = {}): Promise<PublishError[]> {
     const request = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -155,7 +158,7 @@ export class EventSenderEngine {
         ...batch,
         events: batch.events.map(e => ({ ...e, eventDefinition: `eventDefinitions/${e.eventDefinition}` })),
       }),
-      keepalive: true,
+      keepalive,
     };
     return this.fetchImplementation(this.publishUrl, request)
       .then(resp => resp.json())

--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -147,6 +147,7 @@ export class EventSenderEngine {
         ...batch,
         events: batch.events.map(e => ({ ...e, eventDefinition: `eventDefinitions/${e.eventDefinition}` })),
       }),
+      keepalive: true,
     };
     return this.fetchImplementation(this.publishUrl, request)
       .then(resp => resp.json())

--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -77,6 +77,14 @@ export class EventSenderEngine {
         return {};
       })
       .build(fetchImplementation);
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          this.flush();
+        }
+      });
+    }
   }
 
   send(context: Value.Struct, name: string, data?: EventData): void {

--- a/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
+++ b/packages/sdk/src/EventSenderEngine.visibilitychange.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { EventSenderEngine } from './EventSenderEngine';
+
+jest.useFakeTimers();
+
+const BATCH_SIZE = 10;
+const MAX_OPEN_REQUESTS = 10;
+const UPLOAD_LATENCY = 10;
+const FLUSH_TIMEOUT = 10;
+
+describe('EventSenderEngine visibilitychange', () => {
+  const mockFetch = jest.fn(async () => {
+    await new Promise(resolve => setTimeout(resolve, UPLOAD_LATENCY));
+    return new Response(JSON.stringify({ errors: [] }));
+  });
+
+  it('should flush with keepalive when document becomes hidden', async () => {
+    const engine = new EventSenderEngine({
+      clientSecret: 'my_secret',
+      maxBatchSize: BATCH_SIZE,
+      flushTimeoutMilliseconds: FLUSH_TIMEOUT,
+      fetchImplementation: mockFetch as any,
+      region: 'eu',
+      maxOpenRequests: MAX_OPEN_REQUESTS,
+      logger: {},
+    });
+    const uploadSpy = jest.spyOn(engine, 'upload');
+    engine.send({ value: 1 }, 'my_event');
+
+    expect(uploadSpy).not.toHaveBeenCalled();
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    expect(uploadSpy).toHaveBeenCalledWith(expect.any(Object), { keepalive: true });
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('should not use keepalive for regular flushes', async () => {
+    const engine = new EventSenderEngine({
+      clientSecret: 'my_secret',
+      maxBatchSize: BATCH_SIZE,
+      flushTimeoutMilliseconds: FLUSH_TIMEOUT,
+      fetchImplementation: mockFetch as any,
+      region: 'eu',
+      maxOpenRequests: MAX_OPEN_REQUESTS,
+      logger: {},
+    });
+    const uploadSpy = jest.spyOn(engine, 'upload');
+    engine.send({ value: 1 }, 'my_event');
+
+    await jest.advanceTimersByTimeAsync(FLUSH_TIMEOUT);
+
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    expect(uploadSpy).toHaveBeenCalledWith(expect.any(Object), { keepalive: undefined });
+
+    await jest.runAllTimersAsync();
+  });
+});

--- a/packages/sdk/src/fetch-util.ts
+++ b/packages/sdk/src/fetch-util.ts
@@ -33,6 +33,7 @@ type Context = Readonly<{
   headers?: Record<string, string>;
   body?: string;
   signal?: AbortSignal;
+  keepalive?: boolean;
 }>;
 type ContextFetch = (ctx: Context) => Promise<Response>;
 type FetchPrimitive = (next: ContextFetch) => ContextFetch;


### PR DESCRIPTION
## Summary
- Adds `keepalive: true` to event publish fetch requests so browsers don't cancel in-flight uploads when tabs close
- Adds `keepalive` to the `FetchBuilder` `Context` type so it flows through the pipeline
- Listens for `visibilitychange` and flushes queued events when the tab goes hidden, closing the 500ms flush timeout window
- Guarded by `typeof document` check so it's a no-op in Node/backend environments

## Test plan
- [x] Existing tests pass
- [ ] Verify in browser: events queued immediately before tab close are flushed and received

🤖 Generated with [Claude Code](https://claude.com/claude-code)