### PR TITLE
fix: flush events when tab becomes hidden

### DIFF
--- a/packages/sdk/src/EventSenderEngine.ts
+++ b/packages/sdk/src/EventSenderEngine.ts
@@ -77,6 +77,14 @@ export class EventSenderEngine {
         return {};
       })
       .build(fetchImplementation);
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          this.flush();
+        }
+      });
+    }
   }
 
   send(context: Value.Struct, name: string, data?: EventData): void {


### PR DESCRIPTION
## Summary
- Listens for `visibilitychange` and flushes queued events when the tab goes hidden
- Closes the window where events queued within the 500ms flush timeout could be lost on tab close
- Guarded by `typeof document` check so it's a no-op in Node/backend environments

Depends on #309

## Test plan
- [x] Existing tests pass
- [ ] Verify in browser: events queued immediately before tab close are flushed and received

🤖 Generated with [Claude Code](https://claude.com/claude-code)