### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
         scope: '@spotify-confidence'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: setup-environment
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/Commitlint.yml
+++ b/.github/workflows/Commitlint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - id: setup-environment

--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -17,7 +17,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       release_tag_name: ${{ steps.release.outputs.release_tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         id: release
         with:
           command: manifest
@@ -32,11 +32,11 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.release-please.outputs.release_tag_name }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable commit SHAs to mitigate supply chain attacks (e.g. TanStack "Mini Shai-Hulud")

## Test plan
- [ ] CI passes with SHA-pinned actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)