### PR TITLE
test: migrate e2e tests to new Confidence workspace

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,3 +20,5 @@ jobs:
       - run: yarn lint
       - run: yarn format:check
       - run: yarn test
+        env:
+          CONFIDENCE_CLIENT_SECRET: ${{ secrets.CONFIDENCE_CLIENT_SECRET }}

--- a/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
+++ b/packages/openfeature-server-provider/src/ConfidenceServerProvider.e2e.test.ts
@@ -4,7 +4,7 @@ import { createConfidenceServerProvider } from './factory';
 describe('ConfidenceServerProvider E2E tests', () => {
   beforeEach(() => {
     const confidenceProvider = createConfidenceServerProvider({
-      clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
+      clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
       timeout: 2000,
     });
 

--- a/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
+++ b/packages/openfeature-web-provider/src/ConfidenceWebProvider.e2e.test.ts
@@ -9,7 +9,7 @@ OpenFeature.setLogger({
 });
 function createProvider(options: Partial<ConfidenceWebProviderOptions> = {}): Provider {
   return createConfidenceWebProvider({
-    clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
+    clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
     timeout: 1000,
     ...options,
   });

--- a/packages/sdk/src/Confidence.e2e.test.ts
+++ b/packages/sdk/src/Confidence.e2e.test.ts
@@ -7,7 +7,7 @@ describe('Confidence E2E Tests', () => {
     error: jest.fn(),
   };
   const confidence = Confidence.create({
-    clientSecret: 'RxDVTrXvc6op1XxiQ4OaR31dKbJ39aYV',
+    clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
     environment: 'client',
     timeout: 1000,
     logger: loggerMock,


### PR DESCRIPTION
## Summary
- Read client secret from `CONFIDENCE_CLIENT_SECRET` env var instead of hardcoding
- Tests fail loudly if the secret is missing
- CI workflow injects the secret from GitHub Actions secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)