### PR TITLE
fix(sdk): return default value when resolved property is null

### DIFF
--- a/packages/sdk/src/FlagResolution.test.ts
+++ b/packages/sdk/src/FlagResolution.test.ts
@@ -1,0 +1,67 @@
+import { FlagResolution } from './FlagResolution';
+import { ResolveFlagsResponse } from './generated/confidence/flags/resolver/v1/api';
+import { ResolveReason } from './generated/confidence/flags/resolver/v1/types';
+
+function makeResponse(overrides: Partial<Parameters<typeof makeResolvedFlag>[0]> = {}): ResolveFlagsResponse {
+  return {
+    resolvedFlags: [makeResolvedFlag(overrides)],
+    resolveToken: new Uint8Array(),
+    resolveId: 'test-resolve-id',
+  };
+}
+
+function makeResolvedFlag({
+  flag = 'flags/test-flag',
+  variant = 'flags/test-flag/variants/treatment',
+  value = { my_bool: true, my_string: 'hello' } as { [key: string]: any } | undefined,
+  reason = ResolveReason.RESOLVE_REASON_MATCH,
+  shouldApply = true,
+  flagSchema = {
+    schema: {
+      my_bool: { boolSchema: {} },
+      my_string: { stringSchema: {} },
+    },
+  } as any,
+} = {}) {
+  return { flag, variant, value, reason, shouldApply, flagSchema };
+}
+
+describe('FlagResolution', () => {
+  describe('evaluate with null property values', () => {
+    it('should return defaultValue when a resolved property is null', () => {
+      const response = makeResponse({
+        value: { my_bool: true, my_string: null },
+      });
+      const resolution = FlagResolution.ready({}, response);
+
+      const result = resolution.evaluate('test-flag.my_string', 'fallback');
+
+      expect(result.reason).toBe('MATCH');
+      expect(result.value).toBe('fallback');
+    });
+
+    it('should return the resolved value when property is not null', () => {
+      const response = makeResponse({
+        value: { my_bool: true, my_string: 'hello' },
+      });
+      const resolution = FlagResolution.ready({}, response);
+
+      const result = resolution.evaluate('test-flag.my_string', 'fallback');
+
+      expect(result.reason).toBe('MATCH');
+      expect(result.value).toBe('hello');
+    });
+
+    it('should return defaultValue when a resolved boolean property is null', () => {
+      const response = makeResponse({
+        value: { my_bool: null, my_string: 'hello' },
+      });
+      const resolution = FlagResolution.ready({}, response);
+
+      const result = resolution.evaluate('test-flag.my_bool', false);
+
+      expect(result.reason).toBe('MATCH');
+      expect(result.value).toBe(false);
+    });
+  });
+});

--- a/packages/sdk/src/FlagResolution.ts
+++ b/packages/sdk/src/FlagResolution.ts
@@ -117,12 +117,14 @@ export class ReadyFlagResolution implements FlagResolution {
         return result;
       }
 
-      const value = TypeMismatchError.hoist(name, () => Value.get(flag.value, ...steps) as T);
+      const rawValue = TypeMismatchError.hoist(name, () => Value.get(flag.value, ...steps));
 
       const schema = flag.schema.get(...steps);
       TypeMismatchError.hoist(['defaultValue', ...steps], () => {
         schema.assertAssignsTo(defaultValue);
       });
+
+      const value = (rawValue === null || rawValue === undefined ? defaultValue : rawValue) as T;
 
       result = {
         reason,


### PR DESCRIPTION
## Summary
- When a variant property is unset ("default value") in the Confidence UI, the resolve response contains an explicit `null` for that field. `FlagResolution.evaluate()` returned this `null` directly to the caller instead of falling back to the provided `defaultValue`.
- This caused `getBooleanDetails` (and other typed evaluations) to return `null` instead of the client-specified default — regardless of whether the resolve came from the REST API or the local provider.

## Fix
One-line change in `FlagResolution.ts`: after resolving the value from the flag struct, check for `null`/`undefined` and substitute `defaultValue`.

Companion to https://github.com/spotify/confidence-resolver/pull/415 which fixes the resolver to include null fields in the response (matching the REST API).

## Test plan
- [x] 3 new unit tests for null property handling (null string, null boolean, non-null preserved)
- [x] 130 existing SDK unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)