### PR TITLE
fix(sdk): preserve typed error code on resolve failure

### DIFF
--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -3,7 +3,7 @@ import { Closer } from './Closer';
 import { Confidence } from './Confidence';
 import { EventSenderEngine } from './EventSenderEngine';
 import { FlagResolution } from './FlagResolution';
-import { FlagResolverClient, PendingResolution } from './FlagResolverClient';
+import { FlagResolverClient, PendingResolution, ResolveError } from './FlagResolverClient';
 import { FlagEvaluation, State, StateObserver } from './flags';
 
 const flagResolverClientMock: jest.Mocked<FlagResolverClient> = {
@@ -384,6 +384,21 @@ describe('Confidence', () => {
         reason: 'MATCH',
         value: 'mockValue',
         variant: 'mockVariant',
+      });
+    });
+
+    it('should preserve the typed error code when resolve fails at the outer handler', async () => {
+      flagResolverClientMock.resolve.mockReturnValueOnce(
+        PendingResolution.create({}, () => Promise.reject(new ResolveError('TIMEOUT', 'Resolve timeout'))),
+      );
+      await confidence.evaluateFlag('flag1', 'default');
+
+      const result = confidence.evaluateFlag('flag1', 'default');
+      expect(result).toEqual({
+        reason: 'ERROR',
+        value: 'default',
+        errorCode: 'TIMEOUT',
+        errorMessage: 'Resolve timeout',
       });
     });
   });

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -1,4 +1,4 @@
-import { FetchingFlagResolverClient, FlagResolverClient, PendingResolution } from './FlagResolverClient';
+import { FetchingFlagResolverClient, FlagResolverClient, PendingResolution, ResolveError } from './FlagResolverClient';
 import { EventSenderEngine } from './EventSenderEngine';
 import { Value } from './Value';
 import { EventData, EventSender } from './events';
@@ -265,7 +265,8 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
           }
           // only set failed state if this resolve hasn't been superseded
           if (this.pendingFlags?.signal === pending.signal) {
-            this.currentFlags = FlagResolution.failed(context, 'GENERAL', e.message || 'Resolve failed');
+            const errorCode: FlagEvaluation.ErrorCode = e instanceof ResolveError ? e.code : 'GENERAL';
+            this.currentFlags = FlagResolution.failed(context, errorCode, e.message || 'Resolve failed');
           }
         });
     }


### PR DESCRIPTION
## Problem

A resolve failure can be handled in two places, and they disagree on the error code. `FetchingFlagResolverClient.resolve` preserves the typed code (`error instanceof ResolveError ? error.code : 'GENERAL'`), but the outer context/cache handler hardcodes `'GENERAL'` (`FlagResolution.failed(context, 'GENERAL', e.message || 'Resolve failed')`).

So the same failure — e.g. a resolve **timeout** whose `ResolveError('TIMEOUT')` surfaces at the outer handler — is reported as `GENERAL` (with message still `"Resolve timeout"`) instead of `TIMEOUT`. Downstream this splits one failure mode across two error codes; we see both `TIMEOUT` and `GENERAL` rows with identical `"Resolve timeout"` messages.

## Fix

Preserve the typed code at the outer handler too, mirroring the inner one: `const errorCode = e instanceof ResolveError ? e.code : 'GENERAL'`.

## Test

Added a test asserting a `ResolveError('TIMEOUT')` surfacing at the outer handler yields `errorCode === 'TIMEOUT'`.
