### PR TITLE
ci: split e2e tests into separate job with environment secret

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -5,9 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  pull_request_target:
+    branches: [main]
 
+  # PRs fire both pull_request and pull_request_target. The if-conditions
+  # below deduplicate so each job runs exactly once: Build-And-Test on
+  # pull_request (no secrets needed), E2E-Test on pull_request_target
+  # (has access to environment secrets, including from fork PRs).
 jobs:
   Build-And-Test:
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,5 +27,21 @@ jobs:
       - run: yarn lint
       - run: yarn format:check
       - run: yarn test
+
+  E2E-Test:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment: ci-with-e2e-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - id: setup-environment
+        uses: ./.github/actions/setup
+        with:
+          node-version: '20'
+      - run: yarn bundle
+      - run: yarn test:e2e
         env:
           CONFIDENCE_CLIENT_SECRET: ${{ secrets.CONFIDENCE_CLIENT_SECRET }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -34,7 +34,7 @@ jobs:
   E2E-Test:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    environment: ci-with-e2e-test
+    environment: ${{ github.event_name == 'pull_request_target' && 'ci-with-e2e-test' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,6 +8,9 @@ on:
   pull_request_target:
     branches: [main]
 
+permissions:
+  contents: read
+
   # PRs fire both pull_request and pull_request_target. The if-conditions
   # below deduplicate so each job runs exactly once: Build-And-Test on
   # pull_request (no secrets needed), E2E-Test on pull_request_target

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -32,14 +32,14 @@ jobs:
       - run: yarn test
 
   E2E-Test:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'pull_request_target' && 'ci-with-e2e-test' || '' }}
+    environment: ci-with-e2e-test
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - id: setup-environment
         uses: ./.github/actions/setup
         with:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --config prettier.config.js -w .",
     "format:check": "prettier --config prettier.config.js -c .",
     "lint": "eslint 'packages/*/src/**/*.{tsx,ts}'",
-    "test": "jest",
+    "test": "jest --testPathIgnorePatterns '\\.e2e\\.test\\.ts'",
+    "test:e2e": "jest --testPathPattern '\\.e2e\\.test\\.ts'",
     "prepare": "husky install",
     "cm": "git-cz"
   },


### PR DESCRIPTION
## Summary
- Split `Build-And-Test` into two jobs: unit tests (no secrets) and E2E tests (with `ci-with-e2e-test` environment)
- E2E tests run via `pull_request_target` so fork PRs can access the environment secret after maintainer approval
- Added `test:e2e` script and excluded e2e from default `yarn test`
- The `ci-with-e2e-test` environment has a required reviewer protection rule (`openfeature-contrib-maintainers`), so fork PRs need maintainer approval before E2E tests run

## Test plan
- [x] `yarn test` excludes all `*.e2e.test.ts` files
- [x] `yarn test:e2e` runs only the 3 e2e test files
- [x] Unit tests pass (157/157)
- [x] `ci-with-e2e-test` environment has required reviewer protection rule (openfeature-contrib-maintainers)
- [ ] Verify CI runs both jobs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)