### PR TITLE
feat(sdk): add domain option to visitorIdentity cookie

### DIFF
--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -251,7 +251,12 @@ export namespace Value {
 export type Value = Value.Primitive | Value.Struct | Value.List | undefined;
 
 // @public
-export const visitorIdentity: () => Trackable.Manager;
+export const visitorIdentity: ({ domain }?: VisitorIdentityOptions) => Trackable.Manager;
+
+// @public
+export type VisitorIdentityOptions = {
+    domain?: string;
+};
 
 // Warning: (ae-missing-release-tag) "WaitUntil" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -155,8 +155,14 @@ Confidence can provide all flag resolves and tracking events with a browser spec
 The `visitor_id` is stored in a cookie named `cnfdVisitorId`. To add a generated `visitor_id` to the context, use the following:
 
 ```ts
-import { visitorIdentity } from './trackers';
+import { visitorIdentity } from '@spotify-confidence/sdk';
 confidence.track(visitorIdentity());
+```
+
+To share the visitor ID across subdomains, set the `domain` option:
+
+```ts
+confidence.track(visitorIdentity({ domain: '.example.com' }));
 ```
 
 #### Page Views (web)

--- a/packages/sdk/src/trackers/visitorId.ts
+++ b/packages/sdk/src/trackers/visitorId.ts
@@ -4,15 +4,29 @@ import { uuid, Cookie } from '../utils';
 const COOKIE_NAME = 'cnfdVisitorId';
 
 /**
+ * Options for the visitor identity tracker.
+ * @public
+ */
+export type VisitorIdentityOptions = {
+  /** Set the cookie domain to share the visitor ID across subdomains (e.g. '.example.com'). */
+  domain?: string;
+};
+
+/**
  * Visitor Identity which can be used in Cookies
  * @public  */
-export const visitorIdentity = (): Trackable.Manager => controller => {
-  if (typeof document === 'undefined') return;
-  let value = Cookie.get(COOKIE_NAME);
-  if (!value) {
-    value = uuid();
-    // TODO check correct cookie options
-    Cookie.set(COOKIE_NAME, value, { maxAge: 60 * 60 * 24 * 365 * 5 });
-  }
-  controller.setContext({ visitor_id: value });
-};
+export const visitorIdentity =
+  ({ domain }: VisitorIdentityOptions = {}): Trackable.Manager =>
+  controller => {
+    if (typeof document === 'undefined') return;
+    const cookieOptions: Parameters<typeof Cookie.set>[2] = { maxAge: 60 * 60 * 24 * 365 * 5 };
+    if (domain) {
+      cookieOptions.domain = domain;
+    }
+    let value = Cookie.get(COOKIE_NAME);
+    if (!value) {
+      value = uuid();
+    }
+    Cookie.set(COOKIE_NAME, value, cookieOptions);
+    controller.setContext({ visitor_id: value });
+  };


### PR DESCRIPTION
## Summary
- Adds an optional `domain` parameter to `visitorIdentity()` so the `cnfdVisitorId` cookie can be shared across subdomains
- When set, the cookie is always re-written with the domain attribute, migrating existing hostname-scoped cookies automatically

## Usage
```ts
confidence.track(visitorIdentity({ domain: '.confidence.spotify.com' }));
```

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — all 159 tests pass
- [x] API report regenerated
- [ ] Manual: set domain option, verify `document.cookie` shows the cookie with the correct domain attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)