### PR TITLE
docs(csr): add debug logging section to README

### DIFF
--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -88,7 +88,7 @@ const recorder = initSessionRecorder({
   mode: 'automatic', // 'automatic' (default) or 'manual'
 
   // Debug
-  debugLogger: (msg) => console.log(msg), // lifecycle/transport messages (default: off, or console.log when CSR_DEBUG is set in sessionStorage)
+  debugLogger: msg => console.log(msg), // lifecycle/transport messages (default: off, or console.log when CSR_DEBUG is set in sessionStorage)
 });
 ```
 
@@ -124,7 +124,7 @@ The SDK can emit one-line lifecycle and transport messages to help you verify yo
 ```typescript
 const recorder = initSessionRecorder({
   clientSecret: '<your-client-secret>',
-  debugLogger: (msg) => console.log(msg),
+  debugLogger: msg => console.log(msg),
 });
 ```
 

--- a/csr/session-recording/README.md
+++ b/csr/session-recording/README.md
@@ -86,6 +86,9 @@ const recorder = initSessionRecorder({
 
   // Recording mode
   mode: 'automatic', // 'automatic' (default) or 'manual'
+
+  // Debug
+  debugLogger: (msg) => console.log(msg), // lifecycle/transport messages (default: off, or console.log when CSR_DEBUG is set in sessionStorage)
 });
 ```
 
@@ -111,6 +114,33 @@ const recorder = initSessionRecorder({
 ```
 
 See the [`@spotify-confidence/csr-recorder` README](../csr-recorder/README.md#route-parameterization) for the full list of default patterns.
+
+## Debug logging
+
+The SDK can emit one-line lifecycle and transport messages to help you verify your setup and diagnose issues.
+
+### Option 1: pass a logger
+
+```typescript
+const recorder = initSessionRecorder({
+  clientSecret: '<your-client-secret>',
+  debugLogger: (msg) => console.log(msg),
+});
+```
+
+All messages are prefixed with `[CSR]` — you can filter your browser console to quickly find them.
+
+### Option 2: sessionStorage flag
+
+If you can't (or don't want to) change code, open your browser DevTools console and run:
+
+```javascript
+sessionStorage.setItem('CSR_DEBUG', 'true');
+```
+
+Then reload the page. The SDK will detect the flag and log to `console.log` automatically. Remove it with `sessionStorage.removeItem('CSR_DEBUG')` when you're done.
+
+> **Tip:** We recommend enabling debug logging when first integrating the SDK. It lets you confirm that a session is established, events are flowing, and the backend is reachable — all before you open the Confidence dashboard.
 
 ## Manual mode
 


### PR DESCRIPTION
## Summary
- Adds a **Debug logging** section to the session recording README documenting both activation methods: the `debugLogger` option and the `CSR_DEBUG` sessionStorage flag.
- Adds `debugLogger` to the Configuration reference block.

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)