### PR TITLE
build(deps): bump shell-quote to address critical CVE-2026-9277

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
       "path": "@commitlint/cz-commitlint"
     }
   },
+  "resolutions": {
+    "shell-quote": "^1.9.0"
+  },
   "packageManager": "yarn@4.1.0+sha256.81a00df816059803e6b5148acf03ce313cad36b7f6e5af6efa040a15981a6ffb"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18642,10 +18642,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
+"shell-quote@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10c0/a39960107eb086b02394cfceb3c732bd3bf567b568719ff47101448fc3f1bf4a59ecfdd8960ff7ea564d749ef8bda70f2c82a768f22d8c7aeeabf2b64f53b7e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add `resolutions` entry to force `shell-quote@^1.9.0`, fixing CVE-2026-9277 (GHSA-w7jw-789q-3m8p)
- `shell-quote` is a transitive dev dependency via `launch-editor` and `react-dev-utils` -- no production exposure

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)