### PR TITLE
ci: bump node 20 to 22 and update github action versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,19 +4,16 @@ inputs:
   node-version:
     description: 'Node version to setup'
     required: false
-    default: '20'
+    default: '22'
 
 runs:
   using: 'composite'
   steps:
     - name: Setup Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         scope: '@spotify-confidence'
-    - name: Update npm
-      shell: bash
-      run: npm install -g npm@latest
     - name: Install dependencies
       shell: bash
       run: corepack enable && yarn install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: ${{ inputs.node-version }}
         scope: '@spotify-confidence'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
-          node-version: '20'
+          node-version: '22'
       - run: yarn bundle
       - run: yarn lint
       - run: yarn format:check
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
-          node-version: '20'
+          node-version: '22'
       - run: yarn build:csr
       - run: yarn lint:csr
       - run: yarn test:csr
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
-          node-version: '20'
+          node-version: '22'
       - run: yarn bundle
       - run: yarn test:e2e
         env:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: setup-environment
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/Commitlint.yml
+++ b/.github/workflows/Commitlint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - id: setup-environment

--- a/.github/workflows/Commitlint.yml
+++ b/.github/workflows/Commitlint.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: setup-environment
         uses: ./.github/actions/setup
         with:
-          node-version: '20'
+          node-version: '22'
       - run: yarn commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm # Ensure npm >= 11.5.1 for trusted publishing
+        shell: bash
+        run: npm install -g npm@11
       - name: Install dependencies
         shell: bash
         run: corepack enable && yarn install

--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -41,17 +41,17 @@ jobs:
     if: ${{ needs.Release-Please.outputs.releases_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.Release-Please.outputs.release_tag_name }}
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - name: Update npm # Ensure npm 11.5.1 or later for trusted publishing
         shell: bash
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Install dependencies
         shell: bash
         run: corepack enable && yarn install

--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -41,11 +41,11 @@ jobs:
     if: ${{ needs.Release-Please.outputs.releases_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.Release-Please.outputs.release_tag_name }}
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/Release-Please.yml
+++ b/.github/workflows/Release-Please.yml
@@ -49,9 +49,6 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - name: Update npm # Ensure npm 11.5.1 or later for trusted publishing
-        shell: bash
-        run: npm install -g npm@11
       - name: Install dependencies
         shell: bash
         run: corepack enable && yarn install


### PR DESCRIPTION
## Summary
- Bump Node.js from 20 (EOL April 2026) to 22 LTS across all CI workflows
- Update GitHub Action versions (`actions/checkout@v6`, `actions/setup-node@v6`)
- Remove `npm install -g npm@latest` from the setup action — `npm@latest` (v12) now requires Node >= 22.22.2 and isn't needed for builds
- Pin publish step to `npm@11` for trusted publishing (OIDC) support

## Test plan
- [ ] CI passes on this PR (Build, Test, Lint, Commitlint, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)