### PR TITLE
fix: TextEncoder not defined in Node.js test environments

### DIFF
--- a/packages/sdk/src/Confidence.test.ts
+++ b/packages/sdk/src/Confidence.test.ts
@@ -401,5 +401,44 @@ describe('Confidence', () => {
         errorMessage: 'Resolve timeout',
       });
     });
+
+    it('does not throw when window is defined but TextEncoder is not (e.g. jsdom without polyfills)', async () => {
+      const originalWindow = (global as any).window;
+      const originalTextEncoder = (global as any).TextEncoder;
+      (global as any).window = {};
+      delete (global as any).TextEncoder;
+
+      try {
+        const info = jest.fn();
+        const confidenceWithLogger = new Confidence({
+          clientSecret: 'secret',
+          timeout: 10,
+          environment: 'client',
+          logger: { info },
+          eventSenderEngine: eventSenderEngineMock,
+          flagResolverClient: flagResolverClientMock,
+          cacheProvider: () => {
+            throw new Error('Not implemented');
+          },
+          staleFlagTraceConsumer: jest.fn(),
+          emitEvaluationTrace: jest.fn(),
+        });
+
+        await confidenceWithLogger.evaluateFlag('flag1', 'default');
+        expect(() => confidenceWithLogger.evaluateFlag('flag1', 'default')).not.toThrow();
+        expect(info).toHaveBeenCalledWith(expect.stringContaining('Resolve tester'));
+      } finally {
+        if (originalWindow === undefined) {
+          delete (global as any).window;
+        } else {
+          (global as any).window = originalWindow;
+        }
+        if (originalTextEncoder === undefined) {
+          delete (global as any).TextEncoder;
+        } else {
+          (global as any).TextEncoder = originalTextEncoder;
+        }
+      }
+    });
   });
 });

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -367,7 +367,9 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     };
     const jsonString = JSON.stringify(data);
     const base64 =
-      typeof window !== 'undefined' ? utf8ToBase64(jsonString) : Buffer.from(jsonString).toString('base64');
+      typeof window !== 'undefined' && typeof TextEncoder !== 'undefined'
+        ? utf8ToBase64(jsonString)
+        : Buffer.from(jsonString).toString('base64');
     this.config.logger.info?.(
       `Check your flag evaluation for '${flag}' by copy-pasting the payload to the Resolve tester: ${base64}`,
     );


### PR DESCRIPTION
Fix #268

## Problem

`Confidence.showLoggerLink()` picks its base64 encoder by sniffing for `window`:

```ts
const base64 = typeof window !== 'undefined' ? utf8ToBase64(jsonString) : Buffer.from(jsonString).toString('base64');
```

`utf8ToBase64()` (`packages/sdk/src/utils.ts`) calls `new TextEncoder()`. The check assumes that "`window` exists" implies "a full browser environment exists", which does not hold in simulated DOM test environments (e.g. Jest with `testEnvironment: 'jsdom'`, older jsdom versions, or any setup that defines `window` without polyfilling `TextEncoder`).

In those environments the debug logger link throws `ReferenceError: TextEncoder is not defined`, which surfaces during flag evaluation and breaks consumers' test suites even though nothing about the flag evaluation itself is wrong.

## Change

Widen the guard so it feature-detects `TextEncoder` instead of inferring it from `window`, falling back to `Buffer` when the encoder is unavailable:

```ts
const base64 =
  typeof window !== 'undefined' && typeof TextEncoder !== 'undefined'
    ? utf8ToBase64(jsonString)
    : Buffer.from(jsonString).toString('base64');
```

Real browsers are unaffected — they have both `window` and `TextEncoder`, so they keep taking the `utf8ToBase64()` path. Only the broken environment changes behaviour, and there it degrades to the Node encoder rather than throwing.

## Tests

Added a regression test in `packages/sdk/src/Confidence.test.ts` that:

- defines `global.window` while deleting `global.TextEncoder`, simulating a DOM-ish environment without the encoder,
- evaluates a flag and asserts that it does not throw,
- asserts that the "Resolve tester" logger link is still emitted (i.e. the fallback produces output rather than silently skipping),
- restores the original `window` / `TextEncoder` globals in a `finally` block so surrounding tests are unaffected.

`npx jest packages/sdk/src/Confidence.test.ts` — 29 passed, including the new case.

## Files changed

| File | Change |
| --- | --- |
| `packages/sdk/src/Confidence.ts` | Feature-detect `TextEncoder` before using `utf8ToBase64()` |
| `packages/sdk/src/Confidence.test.ts` | Regression test for the missing-`TextEncoder` environment |
