### PR TITLE
feat(sdk): add read-only mode that suppresses apply and telemetry

### DIFF
--- a/api/openfeature-web-provider.d.ts
+++ b/api/openfeature-web-provider.d.ts
@@ -44,6 +44,12 @@ type ConfidenceWebProviderOptions = {
     resolveBaseUrl?: string;
     /** Sets an alternative apply url */
     applyBaseUrl?: string;
+    /**
+     * Read-only mode. When true, flags are resolved to read their values but the SDK
+     * sends no signals back to Confidence: no apply (exposure) signals and no telemetry.
+     * Flag exposures are not recorded, so experiment metrics are unaffected. Defaults to false.
+     */
+    readOnly?: boolean;
 };
 /**
  * Creates an OpenFeature-adhering Confidence Provider

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -85,6 +85,7 @@ export interface ConfidenceOptions {
     library?: 'openfeature' | 'react';
     // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
     logger?: Logger;
+    readOnly?: boolean;
     region?: 'eu' | 'us';
     resolveBaseUrl?: string;
     timeout: number;

--- a/packages/openfeature-web-provider/src/factory.ts
+++ b/packages/openfeature-web-provider/src/factory.ts
@@ -14,6 +14,12 @@ export type ConfidenceWebProviderOptions = {
   resolveBaseUrl?: string;
   /** Sets an alternative apply url */
   applyBaseUrl?: string;
+  /**
+   * Read-only mode. When true, flags are resolved to read their values but the SDK
+   * sends no signals back to Confidence: no apply (exposure) signals and no telemetry.
+   * Flag exposures are not recorded, so experiment metrics are unaffected. Defaults to false.
+   */
+  readOnly?: boolean;
 };
 
 /**

--- a/packages/sdk/src/Confidence.int.test.ts
+++ b/packages/sdk/src/Confidence.int.test.ts
@@ -153,6 +153,58 @@ describe('Confidence integration tests', () => {
   });
 });
 
+describe('Confidence read-only mode', () => {
+  let confidence: Confidence;
+
+  beforeEach(() => {
+    confidence = Confidence.create({
+      clientSecret: '<client-secret>',
+      timeout: 100,
+      environment: 'client',
+      fetchImplementation,
+      readOnly: true,
+    });
+
+    resolveHandlerMock.mockReturnValue(mockResolveResponse);
+    publishHandlerMock.mockReturnValue(mockPublishResponse);
+  });
+
+  afterEach(() => {
+    resolveHandlerMock.mockClear();
+    applyHandlerMock.mockClear();
+    publishHandlerMock.mockClear();
+    telemetryUploadHandlerMock.mockClear();
+  });
+
+  it('resolves flag values with apply=false and no backend logging', async () => {
+    expect(await confidence.getFlag('flag1.str', 'goodbye')).toBe('hello');
+    expect(resolveHandlerMock).toHaveBeenCalled();
+    // apply defaults to false and is omitted from the serialized request; ensure it's never true.
+    const [resolveRequest] = resolveHandlerMock.mock.calls[0];
+    expect(resolveRequest.apply).toBeFalsy();
+  });
+
+  it('never sends an apply signal, even when shouldApply is true', async () => {
+    // Drain any debounced apply that may still be in flight from previous tests, then start clean.
+    await abortableSleep(50);
+    applyHandlerMock.mockClear();
+
+    expect(await confidence.getFlag('flag1.str', 'goodbye')).toBe('hello');
+    // Give any (non-existent) debounced apply a chance to fire.
+    await abortableSleep(50);
+    expect(applyHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it('never uploads telemetry, even on close', async () => {
+    await confidence.getFlag('flag1.str', 'goodbye');
+    // A type mismatch would normally produce an evaluation trace.
+    confidence.evaluateFlag('flag1.str', 123);
+    confidence.close();
+    await abortableSleep(50);
+    expect(telemetryUploadHandlerMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('Telemetry trace integration tests', () => {
   let confidence: Confidence;
 

--- a/packages/sdk/src/Confidence.ts
+++ b/packages/sdk/src/Confidence.ts
@@ -50,6 +50,14 @@ export interface ConfidenceOptions {
   applyBaseUrl?: string;
   /** Disable telemetry */
   disableTelemetry?: boolean;
+  /**
+   * Read-only mode. When true, flags are resolved to read their values but the SDK
+   * sends no signals back to Confidence: no apply (exposure) signals and no telemetry.
+   * Flag exposures are not recorded, so experiment metrics are unaffected. Resolves
+   * are always performed with apply=false, so the backend logs nothing either.
+   * Defaults to false.
+   */
+  readOnly?: boolean;
   /** Allows you to debounce the apply message. Set in ms. 0 is treated as synchronous */
   applyDebounce?: number;
   /**
@@ -412,6 +420,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       resolveBaseUrl,
       applyBaseUrl,
       disableTelemetry = false,
+      readOnly = false,
       applyDebounce = 10,
       waitUntil,
       cache = {},
@@ -420,6 +429,8 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
     if (environment !== 'client' && environment !== 'backend') {
       throw new Error(`Invalid environment: ${environment}. Must be 'client' or 'backend'.`);
     }
+    // Read-only mode suppresses all outbound signals, including telemetry.
+    const telemetryDisabled = disableTelemetry || readOnly;
     const sdk = {
       id: SdkId.SDK_ID_JS_CONFIDENCE,
       version: '0.3.20', // x-release-please-version
@@ -431,7 +442,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       libraryEnum = LibraryTraces_Library.LIBRARY_REACT;
     }
     const telemetry = new Telemetry({
-      disabled: disableTelemetry,
+      disabled: telemetryDisabled,
       environment,
       library: libraryEnum,
     });
@@ -467,6 +478,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       telemetry,
       logger,
       applyDebounce,
+      readOnly,
       waitUntil,
       cacheProvider,
       onEvaluation,
@@ -489,7 +501,7 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
       maxOpenRequests: (50 * 1024) / (estEventSizeKb * maxBatchSize),
       logger,
     });
-    const onClose = !disableTelemetry ? () => telemetry.onFlush?.() : undefined;
+    const onClose = !telemetryDisabled ? () => telemetry.onFlush?.() : undefined;
     return new Confidence({
       ...options,
       flagResolverClient,

--- a/packages/sdk/src/FlagResolverClient.ts
+++ b/packages/sdk/src/FlagResolverClient.ts
@@ -90,6 +90,7 @@ export type FlagResolverClientOptions = {
   clientSecret: string;
   sdk: Sdk;
   applyDebounce: number;
+  readOnly?: boolean;
   resolveTimeout: number;
   environment: 'client' | 'backend';
   region?: 'eu' | 'us';
@@ -107,6 +108,7 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
   private readonly clientSecret: string;
   private readonly sdk: Sdk;
   private readonly applyDebounce: number;
+  private readonly readOnly: boolean;
   private readonly resolveTimeout: number;
   private readonly baseUrl: string;
   private readonly applyBaseUrl: string;
@@ -125,6 +127,7 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
     clientSecret,
     sdk,
     applyDebounce,
+    readOnly = false,
     resolveTimeout,
     // todo refactor to move out environment
     environment,
@@ -154,6 +157,7 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
     this.clientSecret = clientSecret;
     this.sdk = sdk;
     this.applyDebounce = applyDebounce;
+    this.readOnly = readOnly;
     this.onEvaluation = onEvaluation;
     this.logger = logger;
     if (resolveBaseUrl) {
@@ -229,7 +233,9 @@ export class FetchingFlagResolverClient implements FlagResolverClient {
         .then(({ response, isFromCache }) => {
           const latency = performance.now() - start;
           this.markLatency(latency, isFromCache ? TraceStatus.STATUS_CACHED : TraceStatus.STATUS_SUCCESS);
-          return FlagResolution.ready(context, response, this.createApplier(response.resolveToken), this.onEvaluation);
+          // In read-only mode no applier is created, so evaluations never send an apply signal.
+          const applier = this.readOnly ? undefined : this.createApplier(response.resolveToken);
+          return FlagResolution.ready(context, response, applier, this.onEvaluation);
         })
         .catch(error => {
           const latency = performance.now() - start;


### PR DESCRIPTION
## Summary

Adds a `readOnly` option that lets the SDK resolve flag values **without sending any signals back to Confidence** — no apply (exposure) signals and no telemetry.

Previously there was no unified way to turn this off: the only lever was per-evaluation and only affected apply indirectly, and `disableTelemetry` covered just telemetry. Resolves already run with `apply=false` (so the backend logs nothing on resolve); the missing piece was suppressing the client-side apply signal. This makes a true "read-only" preview mode that leaves experiment metrics unaffected.

- `ConfidenceOptions.readOnly` (core SDK): when `true`, telemetry is disabled and no apply signal is sent.
- Implemented by passing **no applier** to the resolution in `FlagResolverClient.resolve()` when read-only — since the applier is optional, evaluations then never enqueue or POST to `flags:apply`.
- Exposed on `ConfidenceWebProviderOptions`; React's `ManagedConfidenceProvider` already spreads `ConfidenceOptions`, so it works there automatically.

```ts
const provider = createConfidenceWebProvider({
  clientSecret: '...',
  timeout: 1000,
  readOnly: true, // resolve values only; no apply signal, no telemetry
});
```

## Changes

- `packages/sdk/src/Confidence.ts`: new `readOnly` option; forces telemetry off and passes `readOnly` to the resolver client.
- `packages/sdk/src/FlagResolverClient.ts`: skips applier creation when read-only.
- `packages/openfeature-web-provider/src/factory.ts`: exposes `readOnly`.
- `packages/sdk/src/Confidence.int.test.ts`: new `read-only mode` tests (resolves values with `apply` never truthy, never sends apply even when `shouldApply: true`, never uploads telemetry on close).
- `api/sdk.api.md`, `api/openfeature-web-provider.d.ts`: regenerated API reports.

## Test plan

- [x] `yarn build`, `yarn lint`: clean.
- [x] `yarn jest` (non-e2e) for sdk + web-provider: 174/174 pass.
- [x] API reports regenerated via `yarn bundle --local`.

Made with [Cursor](https://cursor.com)