### PR TITLE
feat(csr-common): export user activity tags

### DIFF
--- a/csr/csr-common/src/index.ts
+++ b/csr/csr-common/src/index.ts
@@ -35,6 +35,15 @@ export {
 export { stripUrl } from './url';
 
 export {
+  USER_ACTION_CUSTOM_EVENT_TAGS,
+  USER_ACTIVITY_CUSTOM_EVENT_TAGS,
+  isUserActionCustomEventTag,
+  isUserActivityCustomEventTag,
+  type UserActionCustomEventTag,
+  type UserActivityCustomEventTag,
+} from './user-activity';
+
+export {
   MAX_KEY_LENGTH,
   MAX_TAG_VALUE_LENGTH,
   MAX_DISTINCT_KEYS,

--- a/csr/csr-common/src/user-activity.test.ts
+++ b/csr/csr-common/src/user-activity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  USER_ACTION_CUSTOM_EVENT_TAGS,
+  USER_ACTIVITY_CUSTOM_EVENT_TAGS,
+  isUserActionCustomEventTag,
+  isUserActivityCustomEventTag,
+} from './user-activity';
+
+describe('custom event activity', () => {
+  it('defines boundary activity as user actions plus navigation and refocus', () => {
+    expect(USER_ACTIVITY_CUSTOM_EVENT_TAGS).toEqual([
+      ...USER_ACTION_CUSTOM_EVENT_TAGS,
+      'csr:routeChange',
+      'csr:tabRefocus',
+    ]);
+  });
+
+  it('distinguishes direct user actions from broader boundary activity', () => {
+    expect(isUserActionCustomEventTag('csr:click')).toBe(true);
+    expect(isUserActionCustomEventTag('csr:routeChange')).toBe(false);
+    expect(isUserActivityCustomEventTag('csr:routeChange')).toBe(true);
+    expect(isUserActivityCustomEventTag('csr:tabUnfocus')).toBe(false);
+    expect(isUserActivityCustomEventTag('csr:errorMessage')).toBe(false);
+  });
+});

--- a/csr/csr-common/src/user-activity.ts
+++ b/csr/csr-common/src/user-activity.ts
@@ -1,0 +1,36 @@
+import type { CustomEventData } from './events';
+
+export type UserActionCustomEventTag = Extract<
+  CustomEventData['tag'],
+  'csr:click' | 'csr:deadClick' | 'csr:rageClick' | 'csr:input' | 'csr:formFieldReEdit' | 'csr:scrollBack'
+>;
+
+export const USER_ACTION_CUSTOM_EVENT_TAGS: readonly UserActionCustomEventTag[] = [
+  'csr:click',
+  'csr:deadClick',
+  'csr:rageClick',
+  'csr:input',
+  'csr:formFieldReEdit',
+  'csr:scrollBack',
+];
+
+export type UserActivityCustomEventTag =
+  | UserActionCustomEventTag
+  | Extract<CustomEventData['tag'], 'csr:routeChange' | 'csr:tabRefocus'>;
+
+export const USER_ACTIVITY_CUSTOM_EVENT_TAGS: readonly UserActivityCustomEventTag[] = [
+  ...USER_ACTION_CUSTOM_EVENT_TAGS,
+  'csr:routeChange',
+  'csr:tabRefocus',
+];
+
+const userActionCustomEventTags: ReadonlySet<string> = new Set(USER_ACTION_CUSTOM_EVENT_TAGS);
+const userActivityCustomEventTags: ReadonlySet<string> = new Set(USER_ACTIVITY_CUSTOM_EVENT_TAGS);
+
+export function isUserActionCustomEventTag(tag: string): tag is UserActionCustomEventTag {
+  return userActionCustomEventTags.has(tag);
+}
+
+export function isUserActivityCustomEventTag(tag: string): tag is UserActivityCustomEventTag {
+  return userActivityCustomEventTags.has(tag);
+}


### PR DESCRIPTION
## What

Export typed custom-event registries and type guards for:

- direct user actions
- broader user activity, including route changes and tab refocus

This gives recording consumers one shared definition while keeping their
different semantics explicit.

## Validation

- `yarn test:csr` (137 tests)
- `yarn workspace @spotify-confidence/csr-common build`
- csr-common TypeScript check
- `yarn lint:csr`
- `yarn format:check`
- consumer analyzer/video suites against the local csr-common build (488 tests)

#### :heavy_check_mark: Checklist

- [x] All tests are passing
- [x] Relevant documentation updated (public exports)
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Tested in a corresponding example app
