### PR TITLE
fix(build): normalize Windows path separators in rollup external check

### DIFF
--- a/rollup.base.mjs
+++ b/rollup.base.mjs
@@ -110,7 +110,8 @@ function createExternalTest(prefix, external = []) {
  */
 function normalizePath(id, parent = '') {
   const absolute = id.startsWith('.') ? resolve(parent, id) : id;
-  return relative(cwd, absolute);
+  // relative() yields backslashes on Windows, which would break the prefix checks in createExternalTest
+  return relative(cwd, absolute).replaceAll('\\', '/');
 }
 
 /**


### PR DESCRIPTION
## Summary

`normalizePath()` in `rollup.base.mjs` returns the result of `relative()` verbatim. On Windows, `relative()` returns backslash-separated paths (e.g., `build\Confidence.js`), causing the `path.startsWith(prefix)` checks in `createExternalTest` (where `prefix` is `build/`) to fail. Local `build/` imports were consequently misreported as unbundleable external dependencies:

```
Error: Attempt to bundle external dependency build\Confidence.js for import ./Confidence.js.
Are we missing a dependency?
```

Normalizing backslashes to forward slashes resolves the issue on Windows while maintaining full compatibility on POSIX systems (where `relative()` already uses forward slashes).

## Verification

- Tested `yarn bundle` on Windows: builds successfully without path resolution errors.
- Verified test suite passes (`yarn test`).
