### PR TITLE
feat: stateless remote client

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ You can check out the example application, which is built with Next.js and uses 
 # Direct SDK Usage
 
 > [!NOTE]
-> The standalone SDK is being phased out. For new integrations, we recommend using the OpenFeature APIs described above.
+> The standalone `Confidence` class is being phased out. For new integrations, we recommend using the OpenFeature APIs described above.
 
 The vanilla sdk can be used in cases where you want direct access to the Confidence SDK, including event tracking and custom context management.
 
-> **Learn more**: [SDK Documentation](./packages/sdk/README.md)
+The package also provides `ConfidenceClient`, a thin stateless client for a remote resolver that does flag resolution and exposure only. It is the primitive the providers above are moving onto, and is useful directly when resolving from a worker, or when resolving on the server and forwarding the result to the browser to evaluate.
+
+> **Learn more**: [SDK Documentation](./packages/sdk/README.md) · [`ConfidenceClient`](./packages/sdk/README.md#confidenceclient)
 
 ## React Integration
 

--- a/api/sdk.api.md
+++ b/api/sdk.api.md
@@ -71,6 +71,37 @@ export class Confidence implements EventSender, Trackable, FlagResolver {
 }
 
 // @public
+export namespace ConfidenceClient {
+    export type ApplyResult = {
+        ok: true;
+    } | {
+        ok: false;
+        errorCode: 'TIMEOUT' | 'GENERAL';
+        errorMessage: string;
+        status?: number;
+    };
+    export interface Options {
+        fetch?: typeof fetch;
+        flagClientSecret: string;
+        // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
+        logger?: Logger;
+        url?: string;
+    }
+}
+
+// @public
+export class ConfidenceClient {
+    constructor(options: ConfidenceClient.Options);
+    apply(resolveToken: string, flagNames: string | string[], options?: {
+        signal?: AbortSignal;
+    }): Promise<ConfidenceClient.ApplyResult>;
+    resolve(flagNames: string[], context: EvaluationContext, options?: {
+        apply?: boolean;
+        signal?: AbortSignal;
+    }): Promise<FlagBundle>;
+}
+
+// @public
 export interface ConfidenceOptions {
     applyBaseUrl?: string;
     applyDebounce?: number;
@@ -83,7 +114,6 @@ export interface ConfidenceOptions {
     fetchImplementation?: SimpleFetch;
     // @internal
     library?: 'openfeature' | 'react';
-    // Warning: (ae-forgotten-export) The symbol "Logger" needs to be exported by the entry point index.d.ts
     logger?: Logger;
     region?: 'eu' | 'us';
     resolveBaseUrl?: string;
@@ -142,6 +172,12 @@ export interface Contextual<Self extends Contextual<Self>> {
 }
 
 // @public
+export type EvaluationContext = {
+    targeting_key?: string;
+    [key: string]: unknown;
+};
+
+// @public
 export type EventData = Value.Struct & {
     context?: never;
 };
@@ -149,6 +185,36 @@ export type EventData = Value.Struct & {
 // @public
 export interface EventSender extends Contextual<EventSender> {
     track(name: string, data?: EventData): void;
+}
+
+// @public
+export interface FlagBundle {
+    errorCode?: FlagBundle.ErrorCode;
+    errorMessage?: string;
+    flags: Record<string, FlagBundle.Details<FlagBundle.Struct | null> | undefined>;
+    resolveId: string;
+    resolveToken: string;
+}
+
+// @public
+export namespace FlagBundle {
+    export interface Details<T> {
+        assignmentOrigin?: string;
+        errorCode?: ErrorCode;
+        errorMessage?: string;
+        reason: Reason;
+        shouldApply: boolean;
+        value: T;
+        variant?: string;
+    }
+    export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'TIMEOUT' | 'GENERAL';
+    export function evaluate<T extends Value>(bundle: FlagBundle, flagKey: string, defaultValue: T, logger?: Logger): Details<T>;
+    export type Primitive = null | boolean | string | number;
+    export type Reason = 'ERROR' | 'FLAG_ARCHIVED' | 'MATCH' | 'NO_SEGMENT_MATCH' | 'TARGETING_KEY_ERROR' | 'NO_TREATMENT_MATCH' | 'UNSPECIFIED';
+    export type Struct = {
+        [key: string]: Value;
+    };
+    export type Value = Primitive | Struct;
 }
 
 // Warning: (ae-missing-release-tag) "FlagEvaluation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -3,10 +3,12 @@
 ![](https://img.shields.io/badge/lifecycle-beta-a0c3d2.svg)
 
 > [!NOTE]
-> This Confidence standalone SDK is being phased out. For new integrations, we recommend using the OpenFeature APIs directly:
+> The standalone `Confidence` class is being phased out. For new integrations, we recommend using the OpenFeature APIs directly:
 >
 > - **Client-based (SPA)**: Use [@spotify-confidence/openfeature-web-provider](https://github.com/spotify/confidence-sdk-js/blob/main/packages/openfeature-web-provider/README.md)
 > - **Server**: Use [@spotify-confidence/openfeature-server-provider-local](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/js/README.md), which resolves flags in-process with close to zero latency
+>
+> [`ConfidenceClient`](#confidenceclient) is a low-level client for a remote resolver, and will become the engine behind the providers above. Most integrations should use a provider rather than calling it directly.
 
 JavaScript implementation of the Confidence SDK, enables event tracking and feature flagging capabilities in conjunction with the OpenFeature Web SDK.
 
@@ -19,6 +21,145 @@ To add the packages to your dependencies run:
 ```sh
 yarn add @spotify-confidence/sdk
 ```
+
+# ConfidenceClient
+
+`ConfidenceClient` is a thin, stateless client for a remote Confidence resolver. It does flag resolution and exposure only — no event tracking, no context management, no caching.
+
+## When to use it
+
+Prefer a provider over calling this directly:
+
+- **Client-side (SPA)**: [@spotify-confidence/openfeature-web-provider](https://github.com/spotify/confidence-sdk-js/blob/main/packages/openfeature-web-provider/README.md)
+- **Server**: [@spotify-confidence/openfeature-server-provider-local](https://github.com/spotify/confidence-resolver/tree/main/openfeature-provider/js/README.md), which resolves in-process with close to zero latency
+
+Reach for `ConfidenceClient` when you want the underlying primitive instead: resolving from a worker, forwarding a resolve to the browser, or anywhere a provider's lifecycle is more than you need.
+
+There is no lifecycle, no background work and no cached state, so constructing one is free — create it per request or share it at module level, it makes no difference. There is nothing to `close()`.
+
+```ts
+import { ConfidenceClient, FlagBundle } from '@spotify-confidence/sdk';
+
+const client = new ConfidenceClient({ flagClientSecret: 'my secret' });
+
+const bundle = await client.resolve(['tutorial-feature'], { targeting_key: 'user-1' });
+const { value } = FlagBundle.evaluate(bundle, 'tutorial-feature.title', 'default title');
+```
+
+> [!IMPORTANT]
+> The evaluation context is passed to targeting verbatim, so use the wire spelling `targeting_key` — not OpenFeature's `targetingKey`.
+
+## Resolve on the server, evaluate in the browser
+
+Resolving flags in the browser is generally not recommended. Instead resolve once on the server and forward the resulting `FlagBundle` to the client: it is plain JSON, and `FlagBundle.evaluate` is a pure function, so the browser can evaluate flags without a second round trip or a client secret.
+
+Defer exposure with `apply: false` so a flag counts as seen when it is actually used, rather than when it was resolved.
+
+```ts
+// --- server ---
+const bundle = await client.resolve([], { targeting_key: userId }, { apply: false });
+return { props: { bundle } }; // serialize into the page
+
+// --- browser ---
+import { FlagBundle } from '@spotify-confidence/sdk';
+
+const showBanner = FlagBundle.evaluate(bundle, 'promo-banner.enabled', false);
+if (showBanner.shouldApply) {
+  await fetch('/api/apply', { method: 'POST', body: JSON.stringify({ flag: 'promo-banner' }) });
+}
+```
+
+The bundle's `resolveToken` only permits applying the flags it was minted for, which is what makes it safe to round-trip through the browser.
+
+## Pointing at your own resolver
+
+`url` defaults to `https://resolver.confidence.dev`. Set it to target a resolver you run yourself, and pass a `fetch`-compatible transport to reach it — a Cloudflare service binding, for instance:
+
+```ts
+const client = new ConfidenceClient({
+  flagClientSecret: env.CONFIDENCE_CLIENT_SECRET,
+  fetch: env.RESOLVER.fetch.bind(env.RESOLVER),
+  url: 'https://resolver.internal',
+});
+```
+
+> [!NOTE]
+> The `url` option is still used with a service binding: bindings route by binding rather than by hostname, but the request path is taken from the URL, so it has to be a valid absolute URL.
+
+## Resolving flags
+
+`resolve` takes the flag names to resolve — or an empty array for every flag available to the client — and returns a `FlagBundle`.
+
+```ts
+const bundle = await client.resolve(['promo-banner'], { targeting_key: 'user-1', country: 'SE' });
+
+bundle.flags['promo-banner']; // { reason, value, variant, shouldApply, assignmentOrigin }
+bundle.resolveId; // identifies this resolve
+bundle.resolveToken; // empty unless apply was deferred
+```
+
+`apply` defaults to `true`, so a plain `resolve` counts as an exposure.
+
+### Evaluating
+
+`FlagBundle.evaluate` takes a default value, which fixes the expected type. A resolved value that does not match the default's type yields the default with a `TYPE_MISMATCH` error, and dot notation reads into the flag's value:
+
+```ts
+FlagBundle.evaluate(bundle, 'promo-banner', { enabled: false, title: '' });
+FlagBundle.evaluate(bundle, 'promo-banner.title', 'default title');
+```
+
+Each result carries the `reason` the flag resolved the way it did, the assigned `variant`, and `shouldApply`. Pass an optional `Logger` as the fourth argument to have evaluation failures reported.
+
+## Recording exposure
+
+When a resolve deferred exposure, `apply` records it against the bundle's token. Pass one flag name or several; several are sent in a single request.
+
+```ts
+const result = await client.apply(bundle.resolveToken, ['promo-banner']);
+```
+
+Flags whose `shouldApply` is false can be skipped — applying them has no observable effect.
+
+## Errors
+
+Neither `resolve` nor `apply` rejects.
+
+A failed resolve returns an errored bundle rather than throwing, so the failure travels to the browser correctly labelled instead of looking like a missing flag. Evaluating against it yields your defaults with an `ERROR` reason:
+
+```ts
+const bundle = await client.resolve(['promo-banner'], context);
+if (bundle.errorCode) {
+  // 'TIMEOUT' or 'GENERAL' — evaluation still works, and returns defaults
+}
+```
+
+`apply` returns an `ApplyResult` instead of rejecting, because the natural call site is fire-and-forget and an unhandled rejection terminates the process on Node:
+
+```ts
+const result = await client.apply(token, 'promo-banner');
+if (!result.ok) {
+  // result.errorCode, result.errorMessage, and result.status for HTTP failures
+}
+```
+
+Failures are reported through the `logger` if one was passed.
+
+## Timeouts and cancellation
+
+There is no `timeout` option — pass an `AbortSignal`, which covers both deadlines and cancellation:
+
+```ts
+await client.resolve(flags, context, { signal: AbortSignal.timeout(1000) });
+await client.apply(token, flags, { signal: AbortSignal.timeout(1000) });
+```
+
+A signal that aborts on a deadline is reported as `TIMEOUT`; a deliberate `controller.abort()` is not. Neither call retries — for `apply`, inspect `status` to tell a permanent failure (4xx) from a transient one and retry at your own cadence.
+
+# The Confidence class
+
+> [!NOTE]
+> Being phased out — see the recommendations at the top of this page.
 
 ## Initializing the SDK
 

--- a/packages/sdk/src/ConfidenceClient.e2e.test.ts
+++ b/packages/sdk/src/ConfidenceClient.e2e.test.ts
@@ -1,0 +1,281 @@
+import { ConfidenceClient } from './ConfidenceClient';
+import { FlagBundle } from './FlagBundle';
+
+/**
+ * End-to-end tests for the thin client against the real online resolver at
+ * `resolver.confidence.dev` (the client's default url, deliberately left unset
+ * below so the default is covered too).
+ *
+ * These cover what the mocked-transport unit tests structurally cannot: that
+ * the canonical protobuf JSON the client emits is what a real resolver accepts,
+ * that the JSON it sends back decodes into a `FlagBundle`, and that the
+ * `resolve(..., { apply: false })` -> `resolveToken` -> `apply()` round trip
+ * actually works against a server rather than against our own assumptions.
+ *
+ * They use the same `web-sdk-e2e-flag` and context as `Confidence.e2e.test.ts`,
+ * so the two are directly comparable.
+ *
+ * Note that the applies below record real exposures for `web-sdk-e2e-flag`.
+ */
+
+const FLAG = 'web-sdk-e2e-flag';
+// A second flag on the same client, used to check that a resolve token only
+// permits applying the flags it was minted for.
+const OTHER_FLAG = 'custom-targeted-flag';
+
+// Context is passed through to targeting verbatim, so the wire spelling
+// `targeting_key` is what's used here — not OpenFeature's `targetingKey`.
+// `sticky: false` keeps us off the flag's sticky experiment, so the control
+// variant is deterministic.
+const CONTEXT = { targeting_key: 'test-a', sticky: false };
+
+const VARIANT = `flags/${FLAG}/variants/control`;
+const ASSIGNMENT_ORIGIN = `flags/${FLAG}/rules/zphggscnfdpvcp4jy5ui`;
+const CONTROL_VALUE = {
+  str: 'control',
+  bool: false,
+  double: 3.5,
+  int: 3,
+  obj: { str: 'obj control', bool: false, double: 3.6, int: 4, ['obj-obj']: {} },
+};
+
+// Every test here makes at least one network round trip.
+const TIMEOUT = 20_000;
+
+const client = new ConfidenceClient({ flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET! });
+
+describe('ConfidenceClient E2E (resolve)', () => {
+  it(
+    'resolves a flag into a bundle keyed by unprefixed flag name',
+    async () => {
+      const bundle = await client.resolve([FLAG], CONTEXT, { apply: false });
+
+      expect(bundle.resolveId).toBeTruthy();
+      expect(bundle.flags[FLAG]).toEqual({
+        reason: 'MATCH',
+        variant: VARIANT,
+        value: CONTROL_VALUE,
+        shouldApply: true,
+        assignmentOrigin: ASSIGNMENT_ORIGIN,
+      });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'returns a resolve token when apply is deferred',
+    async () => {
+      const { resolveToken } = await client.resolve([FLAG], CONTEXT, { apply: false });
+
+      // Base64 of the encrypted token — opaque here, but it has to survive a
+      // JSON hop to the browser and come back applyable.
+      expect(resolveToken).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'returns no resolve token when the resolve itself applied',
+    async () => {
+      // apply defaults to true, and a resolve that already counted as an
+      // exposure has nothing left to apply — hence the empty token that
+      // `apply()` short-circuits on.
+      const { resolveToken } = await client.resolve([FLAG], CONTEXT);
+
+      expect(resolveToken).toBe('');
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'resolves every flag available to the client for an empty flag list',
+    async () => {
+      const bundle = await client.resolve([], CONTEXT, { apply: false });
+
+      expect(Object.keys(bundle.flags).length).toBeGreaterThan(1);
+      expect(bundle.flags[FLAG]).toMatchObject({ reason: 'MATCH', variant: VARIANT });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'returns an errored bundle carrying the resolver diagnostic for an unknown client secret',
+    async () => {
+      const bogus = new ConfidenceClient({ flagClientSecret: 'not-a-real-client-secret' });
+
+      const bundle = await bogus.resolve([FLAG], CONTEXT, { apply: false });
+
+      expect(bundle.errorMessage).toMatch(/flags:resolve failed: 4\d\d/);
+      expect(FlagBundle.evaluate(bundle, FLAG, 'fallback')).toMatchObject({ reason: 'ERROR', value: 'fallback' });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'labels a real deadline miss as TIMEOUT',
+    async () => {
+      // The client has no timeout option, so `AbortSignal.timeout` is the whole
+      // mechanism — and whether a runtime propagates `TimeoutError` through
+      // `fetch` is exactly the kind of assumption a unit test cannot check.
+      // 1ms is unreachable over the network.
+      const bundle = await client.resolve([FLAG], CONTEXT, { apply: false, signal: AbortSignal.timeout(1) });
+
+      expect(bundle.errorCode).toBe('TIMEOUT');
+      expect(FlagBundle.evaluate(bundle, FLAG, 'fallback')).toMatchObject({
+        reason: 'ERROR',
+        errorCode: 'TIMEOUT',
+        value: 'fallback',
+      });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'returns an errored bundle for a deliberate abort, without labelling it a timeout',
+    async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const bundle = await client.resolve([FLAG], CONTEXT, { apply: false, signal: controller.signal });
+
+      expect(bundle.errorCode).toBe('GENERAL');
+    },
+    TIMEOUT,
+  );
+});
+
+describe('ConfidenceClient E2E (evaluate a forwarded bundle)', () => {
+  // The bundle a browser would see: resolved server-side, serialized into the
+  // page, parsed back out. `FlagBundle.evaluate` is pure, so this is the whole
+  // transport.
+  let forwarded: FlagBundle;
+
+  beforeAll(async () => {
+    const bundle = await client.resolve([FLAG], CONTEXT, { apply: false });
+    forwarded = JSON.parse(JSON.stringify(bundle));
+  }, TIMEOUT);
+
+  it('survives the JSON round trip intact', () => {
+    expect(forwarded.flags[FLAG]?.value).toEqual(CONTROL_VALUE);
+    expect(forwarded.resolveToken).toBeTruthy();
+  });
+
+  it('evaluates the whole flag against an object default', () => {
+    const details = FlagBundle.evaluate(forwarded, FLAG, { str: 'default', int: 0 });
+
+    expect(details.value).toEqual(CONTROL_VALUE);
+    expect(details.reason).toBe('MATCH');
+    expect(details.variant).toBe(VARIANT);
+    expect(details.shouldApply).toBe(true);
+  });
+
+  it('evaluates dot paths into the flag value', () => {
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.bool`, true).value).toBe(false);
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.int`, 10).value).toBe(3);
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.double`, 10).value).toBe(3.5);
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.str`, 'default').value).toBe('control');
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.obj`, {}).value).toEqual(CONTROL_VALUE.obj);
+    expect(FlagBundle.evaluate(forwarded, `${FLAG}.obj.double`, 1).value).toBe(3.6);
+  });
+
+  it('returns the default with an ERROR reason on a type mismatch', () => {
+    const details = FlagBundle.evaluate(forwarded, `${FLAG}.str`, 42);
+
+    expect(details.value).toBe(42);
+    expect(details.reason).toBe('ERROR');
+    expect(details.errorCode).toBe('TYPE_MISMATCH');
+  });
+
+  it('returns the default with FLAG_NOT_FOUND for a flag outside the bundle', () => {
+    const details = FlagBundle.evaluate(forwarded, 'no-such-flag', 'fallback');
+
+    expect(details.value).toBe('fallback');
+    expect(details.reason).toBe('ERROR');
+    expect(details.errorCode).toBe('FLAG_NOT_FOUND');
+  });
+});
+
+describe('ConfidenceClient E2E (apply)', () => {
+  let resolveToken: string;
+
+  beforeAll(async () => {
+    ({ resolveToken } = await client.resolve([FLAG], CONTEXT, { apply: false }));
+  }, TIMEOUT);
+
+  it(
+    'records exposure for a single flag name',
+    async () => {
+      await expect(client.apply(resolveToken, FLAG)).resolves.toEqual({ ok: true });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'records exposure for an array of flag names',
+    async () => {
+      await expect(client.apply(resolveToken, [FLAG])).resolves.toEqual({ ok: true });
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'reports a resolve token the resolver will not accept, with a 4xx status',
+    async () => {
+      const result = await client.apply('bm90LWEtdG9rZW4=', FLAG);
+
+      expect(result).toMatchObject({ ok: false, errorCode: 'GENERAL' });
+      // A permanent failure: the status is what tells a caller not to retry.
+      expect(result.ok === false && result.status).toBeGreaterThanOrEqual(400);
+      expect(result.ok === false && result.status).toBeLessThan(500);
+      expect(result.ok === false && result.errorMessage).toMatch(/flags:apply failed: 4\d\d/);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'fails for a flag the resolve token does not cover',
+    async () => {
+      // The token above was minted for FLAG alone. A token only permits applying
+      // the assignments it actually carries — which is what makes it safe to
+      // round-trip through the browser.
+      const result = await client.apply(resolveToken, OTHER_FLAG);
+
+      expect(result).toMatchObject({ ok: false, status: 400 });
+      expect(result.ok === false && result.errorMessage).toMatch(
+        /Flag in resolve token does not match flag in request/,
+      );
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'fails the whole batch when one flag is not covered by the token',
+    async () => {
+      // Failure covers the whole call, including the flag the token does
+      // carry — an apply naming a flag it never resolved isn't partly right.
+      const result = await client.apply(resolveToken, [FLAG, OTHER_FLAG]);
+
+      expect(result).toMatchObject({ ok: false, status: 400 });
+      expect(result.ok === false && result.errorMessage).toMatch(
+        /Flag in resolve token does not match flag in request/,
+      );
+    },
+    TIMEOUT,
+  );
+
+  it(
+    'reports a timed-out apply as TIMEOUT',
+    async () => {
+      const result = await client.apply(resolveToken, FLAG, { signal: AbortSignal.timeout(1) });
+
+      // No status: nothing came back, so a caller could reasonably retry this one.
+      expect(result).toEqual({
+        ok: false,
+        errorCode: 'TIMEOUT',
+        errorMessage: expect.any(String),
+        status: undefined,
+      });
+    },
+    TIMEOUT,
+  );
+});

--- a/packages/sdk/src/ConfidenceClient.test.ts
+++ b/packages/sdk/src/ConfidenceClient.test.ts
@@ -1,0 +1,396 @@
+import { ConfidenceClient } from './ConfidenceClient';
+import { FlagBundle } from './FlagBundle';
+
+const SECRET = 'test-client-secret';
+
+/**
+ * A canonical protobuf JSON `ResolveFlagsResponse` — the shape pbjson emits
+ * (lowerCamelCase fields, enums as proto-name strings, bytes as base64).
+ * Default-valued fields are omitted, as canonical JSON requires.
+ */
+const RESOLVE_RESPONSE = {
+  resolvedFlags: [
+    {
+      flag: 'flags/promo-banner',
+      variant: 'flags/promo-banner/variants/treatment',
+      value: { show: true, text: 'Hello', nested: { count: 3 } },
+      reason: 'RESOLVE_REASON_MATCH',
+      shouldApply: true,
+      assignmentOrigin: 'rule-1',
+    },
+    {
+      flag: 'flags/checkout-redesign',
+      reason: 'RESOLVE_REASON_NO_SEGMENT_MATCH',
+      // shouldApply omitted — canonical JSON omits `false`
+    },
+  ],
+  resolveToken: 'AQIDBP8=', // bytes [1, 2, 3, 4, 255]
+  resolveId: 'resolve-123',
+};
+
+function mockTransport(
+  responseBody: unknown = RESOLVE_RESPONSE,
+  { status = 200, statusText = 'OK', body }: { status?: number; statusText?: string; body?: string } = {},
+) {
+  const fetchImpl = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    void url;
+    void init;
+    return new Response(body ?? JSON.stringify(responseBody), {
+      status,
+      statusText,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  return fetchImpl as unknown as typeof fetch & { mock: (typeof fetchImpl)['mock'] };
+}
+
+function requestBody(fetchImpl: { mock: { calls: any[][] } }, call = 0): any {
+  return JSON.parse(fetchImpl.mock.calls[call][1].body);
+}
+
+function client(fetchImpl: typeof fetch, url?: string) {
+  return new ConfidenceClient({ flagClientSecret: SECRET, url, fetch: fetchImpl });
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(b64, 'base64'));
+}
+
+/** What `fetch` rejects with when an `AbortSignal.timeout()` fires. */
+function timeoutError(): Error {
+  return new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+}
+
+describe('ConfidenceClient', () => {
+  describe('resolve', () => {
+    it('posts canonical protobuf JSON to /v1/flags:resolve', async () => {
+      const fetchImpl = mockTransport();
+      await client(fetchImpl).resolve(['promo-banner', 'checkout-redesign'], {
+        targeting_key: 'user-1',
+        country: 'SE',
+      });
+
+      const [url, init] = (fetchImpl as any).mock.calls[0];
+      expect(url).toBe('https://resolver.confidence.dev/v1/flags:resolve');
+      expect(init.method).toBe('POST');
+      expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+
+      expect(requestBody(fetchImpl as any)).toEqual({
+        flags: ['flags/promo-banner', 'flags/checkout-redesign'],
+        // Context is passed through verbatim — `targeting_key`, not `targetingKey`
+        evaluationContext: { targeting_key: 'user-1', country: 'SE' },
+        clientSecret: SECRET,
+        apply: true,
+        sdk: { id: 'SDK_ID_JS_CONFIDENCE', version: expect.any(String) },
+      });
+    });
+
+    it('applies by default so naive usage never loses exposure data', async () => {
+      const fetchImpl = mockTransport();
+      await client(fetchImpl).resolve(['promo-banner'], {});
+      expect(requestBody(fetchImpl as any).apply).toBe(true);
+    });
+
+    it('omits `apply` when false, which proto3 decodes back to false', async () => {
+      const fetchImpl = mockTransport();
+      await client(fetchImpl).resolve(['promo-banner'], {}, { apply: false });
+      // Canonical protobuf JSON omits default-valued fields. A missing bool
+      // decodes to false, so a deferred-apply resolve stays deferred.
+      expect(requestBody(fetchImpl as any)).not.toHaveProperty('apply');
+    });
+
+    it('sends no `flags` for an empty array, meaning "all flags"', async () => {
+      const fetchImpl = mockTransport();
+      await client(fetchImpl).resolve([], { targeting_key: 'user-1' });
+      expect(requestBody(fetchImpl as any)).not.toHaveProperty('flags');
+    });
+
+    it('converts the response into a FlagBundle keyed by unprefixed flag name', async () => {
+      const bundle = await client(mockTransport()).resolve(['promo-banner'], {});
+
+      expect(Object.keys(bundle.flags)).toEqual(['promo-banner', 'checkout-redesign']);
+      expect(bundle.resolveId).toBe('resolve-123');
+      expect(bundle.flags['promo-banner']).toEqual({
+        reason: 'MATCH',
+        variant: 'flags/promo-banner/variants/treatment',
+        value: { show: true, text: 'Hello', nested: { count: 3 } },
+        shouldApply: true,
+        assignmentOrigin: 'rule-1',
+      });
+      expect(bundle.flags['checkout-redesign']).toMatchObject({
+        reason: 'NO_SEGMENT_MATCH',
+        value: null,
+        shouldApply: false,
+      });
+    });
+
+    it('exposes resolveToken as a base64 string so the bundle is JSON-forwardable', async () => {
+      const bundle = await client(mockTransport()).resolve(['promo-banner'], {});
+      expect(bundle.resolveToken).toBe('AQIDBP8=');
+      expect(JSON.parse(JSON.stringify(bundle)).resolveToken).toBe('AQIDBP8=');
+    });
+
+    it('returns an errored bundle on HTTP errors, surfacing the resolver diagnostic', async () => {
+      const fetchImpl = mockTransport(undefined, {
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: 'client secret not found: requested=te***et, available=[ab***cd]',
+      });
+      const bundle = await client(fetchImpl).resolve(['promo-banner'], {});
+
+      expect(bundle.errorCode).toBe('GENERAL');
+      expect(bundle.errorMessage).toMatch(/500 Internal Server Error - client secret not found/);
+      expect(bundle.flags).toEqual({});
+    });
+
+    it('returns an errored bundle on transport errors', async () => {
+      const fetchImpl = jest.fn(async () => {
+        throw new Error('connect ECONNREFUSED');
+      }) as unknown as typeof fetch;
+      const bundle = await client(fetchImpl).resolve(['promo-banner'], {});
+
+      expect(bundle.errorCode).toBe('GENERAL');
+      expect(bundle.errorMessage).toMatch('connect ECONNREFUSED');
+    });
+
+    it('returns an errored bundle on a malformed response body', async () => {
+      const fetchImpl = jest.fn(async () => new Response('not json', { status: 200 })) as unknown as typeof fetch;
+      const bundle = await client(fetchImpl).resolve(['promo-banner'], {});
+
+      expect(bundle.errorCode).toBe('GENERAL');
+    });
+
+    it('errored bundles evaluate to the default with an ERROR reason', async () => {
+      const fetchImpl = jest.fn(async () => {
+        throw new Error('connect ECONNREFUSED');
+      }) as unknown as typeof fetch;
+      // The bundle is still plain JSON, so the failure reaches a browser
+      // labelled as an error rather than as a missing flag.
+      const forwarded = JSON.parse(JSON.stringify(await client(fetchImpl).resolve(['promo-banner'], {})));
+
+      expect(FlagBundle.evaluate(forwarded, 'promo-banner.text', 'fallback')).toMatchObject({
+        reason: 'ERROR',
+        errorCode: 'GENERAL',
+        value: 'fallback',
+        shouldApply: false,
+      });
+    });
+
+    it('forwards the abort signal to the transport', async () => {
+      const fetchImpl = mockTransport();
+      const signal = AbortSignal.timeout(5_000);
+      await client(fetchImpl).resolve(['promo-banner'], {}, { signal });
+      expect((fetchImpl as any).mock.calls[0][1].signal).toBe(signal);
+    });
+
+    it('labels a timed-out resolve TIMEOUT rather than GENERAL', async () => {
+      // There is no timeout option — `AbortSignal.timeout()` is the whole
+      // mechanism — so the errored bundle has to distinguish a slow resolver
+      // from a misconfigured one.
+      const fetchImpl = jest.fn(async () => {
+        throw timeoutError();
+      }) as unknown as typeof fetch;
+      const bundle = await client(fetchImpl).resolve(['promo-banner'], {});
+
+      expect(bundle.errorCode).toBe('TIMEOUT');
+      expect(FlagBundle.evaluate(bundle, 'promo-banner.text', 'fallback')).toMatchObject({
+        reason: 'ERROR',
+        errorCode: 'TIMEOUT',
+        value: 'fallback',
+      });
+    });
+
+    it('labels a timeout nested under `cause` TIMEOUT too', async () => {
+      // Some runtimes wrap the abort reason rather than surfacing it directly.
+      const fetchImpl = jest.fn(async () => {
+        throw Object.assign(new Error('fetch failed'), { cause: timeoutError() });
+      }) as unknown as typeof fetch;
+      expect((await client(fetchImpl).resolve(['promo-banner'], {})).errorCode).toBe('TIMEOUT');
+    });
+
+    it('labels a deliberate abort GENERAL, not TIMEOUT', async () => {
+      // The caller who aborted already knows they did; only a deadline is a timeout.
+      const fetchImpl = jest.fn(async () => {
+        throw new DOMException('This operation was aborted', 'AbortError');
+      }) as unknown as typeof fetch;
+      expect((await client(fetchImpl).resolve(['promo-banner'], {})).errorCode).toBe('GENERAL');
+    });
+
+    it('normalizes trailing slashes on the base url', async () => {
+      const fetchImpl = mockTransport();
+      await client(fetchImpl, 'https://my-resolver.example.com//').resolve(['promo-banner'], {});
+      expect((fetchImpl as any).mock.calls[0][0]).toBe('https://my-resolver.example.com/v1/flags:resolve');
+    });
+  });
+
+  describe('apply', () => {
+    it('posts canonical protobuf JSON to /v1/flags:apply', async () => {
+      const fetchImpl = mockTransport({});
+      await client(fetchImpl).apply('AQIDBP8=', ['promo-banner', 'checkout-redesign']);
+
+      const [url] = (fetchImpl as any).mock.calls[0];
+      expect(url).toBe('https://resolver.confidence.dev/v1/flags:apply');
+
+      const body = requestBody(fetchImpl as any);
+      expect(body.flags.map((f: any) => f.flag)).toEqual(['flags/promo-banner', 'flags/checkout-redesign']);
+      expect(body.clientSecret).toBe(SECRET);
+      expect(body.resolveToken).toBe('AQIDBP8=');
+      expect(bytesFromBase64(body.resolveToken)).toEqual(new Uint8Array([1, 2, 3, 4, 255]));
+      // Timestamps must be RFC3339 for pbjson to accept them
+      expect(body.sendTime).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+      expect(Number.isNaN(Date.parse(body.flags[0].applyTime))).toBe(false);
+    });
+
+    it('accepts a single flag name', async () => {
+      const fetchImpl = mockTransport({});
+      await client(fetchImpl).apply('AQIDBP8=', 'promo-banner');
+      expect(requestBody(fetchImpl as any).flags).toEqual([
+        { flag: 'flags/promo-banner', applyTime: expect.any(String) },
+      ]);
+    });
+
+    it('does not call the network without a resolve token', async () => {
+      // A resolve with apply=true returns an empty token; there is nothing to apply.
+      const fetchImpl = mockTransport({});
+      await expect(client(fetchImpl).apply('', 'promo-banner')).resolves.toEqual({ ok: true });
+      expect((fetchImpl as any).mock.calls).toHaveLength(0);
+    });
+
+    it('does not call the network for an empty flag list', async () => {
+      const fetchImpl = mockTransport({});
+      await expect(client(fetchImpl).apply('AQIDBP8=', [])).resolves.toEqual({ ok: true });
+      expect((fetchImpl as any).mock.calls).toHaveLength(0);
+    });
+
+    it('tolerates an empty response body', async () => {
+      const fetchImpl = mockTransport(undefined, { body: '' });
+      await expect(client(fetchImpl).apply('AQIDBP8=', 'promo-banner')).resolves.toEqual({ ok: true });
+    });
+
+    it('reports HTTP errors as a result, carrying the status so callers can retry 5xx only', async () => {
+      const fetchImpl = mockTransport(undefined, { status: 403, statusText: 'Forbidden' });
+      await expect(client(fetchImpl).apply('AQIDBP8=', 'promo-banner')).resolves.toEqual({
+        ok: false,
+        errorCode: 'GENERAL',
+        errorMessage: expect.stringMatching(/403 Forbidden/),
+        status: 403,
+      });
+    });
+
+    it('reports transport errors as a result, with no status', async () => {
+      const fetchImpl = jest.fn(async () => {
+        throw new Error('connect ECONNREFUSED');
+      }) as unknown as typeof fetch;
+      await expect(client(fetchImpl).apply('AQIDBP8=', 'promo-banner')).resolves.toEqual({
+        ok: false,
+        errorCode: 'GENERAL',
+        errorMessage: expect.stringMatching('connect ECONNREFUSED'),
+        status: undefined,
+      });
+    });
+
+    it('never rejects, so an un-awaited apply cannot become an unhandled rejection', async () => {
+      const fetchImpl = jest.fn(async () => {
+        throw new Error('connect ECONNREFUSED');
+      }) as unknown as typeof fetch;
+      // Node terminates the process on an unhandled rejection, and the natural
+      // call site for exposure telemetry is fire-and-forget.
+      const promise = client(fetchImpl).apply('AQIDBP8=', 'promo-banner');
+      await expect(promise).resolves.toMatchObject({ ok: false });
+    });
+
+    it('reports a malformed resolve token as a result rather than throwing', async () => {
+      const fetchImpl = mockTransport({});
+      // Buffer.from is lenient, so force the browser path where atob throws.
+      const buffer = (globalThis as any).Buffer;
+      delete (globalThis as any).Buffer;
+      try {
+        await expect(client(fetchImpl).apply('not!valid!base64', 'promo-banner')).resolves.toMatchObject({
+          ok: false,
+          errorCode: 'GENERAL',
+        });
+      } finally {
+        (globalThis as any).Buffer = buffer;
+      }
+    });
+
+    it('forwards the abort signal to the transport', async () => {
+      const fetchImpl = mockTransport({});
+      const signal = AbortSignal.timeout(5_000);
+      await client(fetchImpl).apply('AQIDBP8=', 'promo-banner', { signal });
+      expect((fetchImpl as any).mock.calls[0][1].signal).toBe(signal);
+    });
+
+    it('reports a timed-out apply as TIMEOUT', async () => {
+      const fetchImpl = jest.fn(async () => {
+        throw timeoutError();
+      }) as unknown as typeof fetch;
+      await expect(client(fetchImpl).apply('AQIDBP8=', 'promo-banner')).resolves.toMatchObject({
+        ok: false,
+        errorCode: 'TIMEOUT',
+      });
+    });
+  });
+
+  describe('FlagBundle.evaluate', () => {
+    const bundle = async () => client(mockTransport()).resolve(['promo-banner'], {});
+
+    it('evaluates a whole flag against an object default', async () => {
+      const details = FlagBundle.evaluate(await bundle(), 'promo-banner', { show: false, text: '' });
+      expect(details.value).toEqual({ show: true, text: 'Hello', nested: { count: 3 } });
+      expect(details.reason).toBe('MATCH');
+      expect(details.shouldApply).toBe(true);
+    });
+
+    it('evaluates a dot path into the flag value', async () => {
+      expect(FlagBundle.evaluate(await bundle(), 'promo-banner.text', 'default').value).toBe('Hello');
+      expect(FlagBundle.evaluate(await bundle(), 'promo-banner.nested.count', 0).value).toBe(3);
+    });
+
+    it('returns the default with an ERROR reason on type mismatch', async () => {
+      const details = FlagBundle.evaluate(await bundle(), 'promo-banner.text', 42);
+      expect(details.value).toBe(42);
+      expect(details.reason).toBe('ERROR');
+      expect(details.errorCode).toBe('TYPE_MISMATCH');
+    });
+
+    it('returns the default with FLAG_NOT_FOUND for an unknown flag', async () => {
+      const details = FlagBundle.evaluate(await bundle(), 'no-such-flag', false);
+      expect(details.value).toBe(false);
+      expect(details.reason).toBe('ERROR');
+      expect(details.errorCode).toBe('FLAG_NOT_FOUND');
+    });
+
+    it('never throws, even on a garbage bundle', async () => {
+      const empty: FlagBundle = { flags: {}, resolveId: '', resolveToken: '' };
+      expect(() => FlagBundle.evaluate(empty, 'x.y.z', 'fallback')).not.toThrow();
+      expect(FlagBundle.evaluate(empty, 'x.y.z', 'fallback').value).toBe('fallback');
+    });
+
+    it('substitutes the default for a flag that resolved to no value', async () => {
+      const details = FlagBundle.evaluate(await bundle(), 'checkout-redesign', { enabled: false });
+      expect(details.value).toEqual({ enabled: false });
+      expect(details.reason).toBe('NO_SEGMENT_MATCH');
+    });
+
+    it('logs evaluation failures when a logger is passed', async () => {
+      const warn = jest.fn();
+      FlagBundle.evaluate(await bundle(), 'no-such-flag', 'fallback', { warn });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('flag not found'));
+    });
+  });
+
+  describe('statelessness', () => {
+    it('does no work on construction', () => {
+      const fetchImpl = mockTransport();
+      expect(new ConfidenceClient({ flagClientSecret: SECRET, fetch: fetchImpl })).toBeDefined();
+      expect((fetchImpl as any).mock.calls).toHaveLength(0);
+    });
+
+    it('has no lifecycle methods to forget to call', () => {
+      const instance = client(mockTransport()) as unknown as Record<string, unknown>;
+      expect(instance.initialize).toBeUndefined();
+      expect(instance.close).toBeUndefined();
+    });
+  });
+});

--- a/packages/sdk/src/ConfidenceClient.ts
+++ b/packages/sdk/src/ConfidenceClient.ts
@@ -1,0 +1,266 @@
+import {
+  ApplyFlagsRequest,
+  ResolveFlagsRequest,
+  ResolveFlagsResponse,
+} from './generated/confidence/flags/resolver/v1/api';
+import { ResolveReason, Sdk, SdkId } from './generated/confidence/flags/resolver/v1/types';
+import { base64FromBytes, bytesFromBase64 } from './base64';
+import { FlagBundle } from './FlagBundle';
+import { Logger } from './logger';
+
+const DEFAULT_URL = 'https://resolver.confidence.dev';
+const FLAG_PREFIX = 'flags/';
+
+// TODO: a dedicated SDK id for the thin client would make its resolve traffic
+// distinguishable from the rest of the JS SDK. Additive proto change.
+const SDK: Sdk = {
+  id: SdkId.SDK_ID_JS_CONFIDENCE,
+  version: '0.3.20', // x-release-please-version
+};
+
+/**
+ * Evaluation context, passed through to targeting verbatim.
+ *
+ * Note the wire spelling `targeting_key` — this is the resolver's contract, not
+ * OpenFeature's `targetingKey`.
+ * @public
+ */
+export type EvaluationContext = {
+  /** The id of the randomization unit */
+  targeting_key?: string;
+  /** Any other attribute used for targeting */
+  [key: string]: unknown;
+};
+
+/**
+ * Types belonging to {@link (ConfidenceClient:class)}
+ * @public
+ */
+export namespace ConfidenceClient {
+  // Types only, so this is erased and may precede the class it merges with.
+
+  /** Options for constructing a {@link (ConfidenceClient:class)} */
+  export interface Options {
+    /** Credentials identifying the client and the flags available to it */
+    flagClientSecret: string;
+    /**
+     * Resolver base URL. Also used for the request path when `fetch` is a
+     * Cloudflare service binding (bindings route by binding, not by hostname).
+     *
+     * Defaults to `https://resolver.confidence.dev`.
+     */
+    url?: string;
+    /** fetch-compatible transport. Pass a Cloudflare service binding here. */
+    fetch?: typeof fetch;
+    /** Optional logger. Nothing is logged when omitted. */
+    logger?: Logger;
+  }
+
+  /** The outcome of {@link (ConfidenceClient:class).apply} */
+  export type ApplyResult =
+    | { ok: true }
+    | {
+        /** The exposure was not recorded */
+        ok: false;
+        /** `TIMEOUT` when the signal aborted with a `TimeoutError` */
+        errorCode: 'TIMEOUT' | 'GENERAL';
+        /** Human-readable cause */
+        errorMessage: string;
+        /** HTTP status, absent for transport failures, timeouts and aborts */
+        status?: number;
+      };
+}
+
+/**
+ * A thin, stateless flag client for use against a remote resolver — a
+ * Confidence resolver Worker reached via service binding, or
+ * `resolver.confidence.dev` over HTTP.
+ *
+ * There is no lifecycle, no background work and no cached state: constructing
+ * one is free, so it can be created per request or shared at module level —
+ * it makes no difference.
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export class ConfidenceClient {
+  private readonly clientSecret: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger?: Logger;
+
+  /** Create a client. Does no work */
+  constructor(options: ConfidenceClient.Options) {
+    this.clientSecret = options.flagClientSecret;
+    // Trailing slashes would produce '//v1/flags:resolve'.
+    this.baseUrl = (options.url ?? DEFAULT_URL).replace(/\/+$/, '');
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Resolve the named flags — or all flags available to the client, when the
+   * array is empty.
+   *
+   * `apply` defaults to true, so a resolve counts as an exposure. Pass
+   * `{ apply: false }` to defer exposure to an explicit
+   * {@link (ConfidenceClient:class).apply} call; the returned bundle then
+   * carries a resolve token to apply against.
+   *
+   * There is no timeout option — pass a `signal` instead, which covers both
+   * deadlines and cancellation with one parameter:
+   * `resolve(flags, ctx, \{ signal: AbortSignal.timeout(1000) \})`. A signal that
+   * aborts with a `TimeoutError` is reported as `errorCode: 'TIMEOUT'`.
+   *
+   * Never rejects. A transport, HTTP, timeout or decoding failure yields an
+   * errored bundle instead: {@link (FlagBundle:namespace).evaluate} then returns
+   * defaults with an `ERROR` reason, and because the bundle is still plain JSON
+   * the failure travels to the browser correctly labelled. Callers that want to
+   * branch can check `errorCode` on the bundle.
+   */
+  async resolve(
+    flagNames: string[],
+    context: EvaluationContext,
+    options?: { apply?: boolean; signal?: AbortSignal },
+  ): Promise<FlagBundle> {
+    try {
+      const request: ResolveFlagsRequest = {
+        flags: flagNames.map(name => FLAG_PREFIX + name),
+        evaluationContext: context,
+        apply: options?.apply ?? true,
+        clientSecret: this.clientSecret,
+        sdk: SDK,
+      };
+      const response = await this.post('/v1/flags:resolve', ResolveFlagsRequest.toJSON(request), options?.signal);
+      return createBundle(ResolveFlagsResponse.fromJSON(await response.json()));
+    } catch (err) {
+      // Named once here; evaluation would otherwise report it per flag.
+      this.logger?.warn?.('Resolve failed, returning an errored bundle. %s', String(err));
+      return erroredBundle(isTimeout(err) ? 'TIMEOUT' : 'GENERAL', String(err));
+    }
+  }
+
+  /**
+   * Record exposure for flags from an earlier `resolve(..., \{ apply: false \})`.
+   *
+   * Flags whose {@link (FlagBundle:namespace).Details.shouldApply | shouldApply}
+   * is false can be skipped to save a request — applying them has no observable
+   * effect.
+   *
+   * A token only permits applying the flags it was minted for; naming any other
+   * flag fails the call in full.
+   *
+   * Never rejects — failures come back as
+   * {@link (ConfidenceClient:namespace).ApplyResult} and are logged. Pass
+   * `\{ signal: AbortSignal.timeout(1000) \}` to bound it.
+   */
+  async apply(
+    resolveToken: string,
+    flagNames: string | string[],
+    options?: { signal?: AbortSignal },
+  ): Promise<ConfidenceClient.ApplyResult> {
+    const names = typeof flagNames === 'string' ? [flagNames] : flagNames;
+    // A resolve with apply=true returns no token, and there is nothing to
+    // apply for an empty flag list — save the round trip either way.
+    if (!resolveToken || names.length === 0) return { ok: true };
+
+    try {
+      const now = new Date();
+      const request: ApplyFlagsRequest = {
+        flags: names.map(name => ({ flag: FLAG_PREFIX + name, applyTime: now })),
+        clientSecret: this.clientSecret,
+        // Throws on malformed base64 in browsers; caught below with everything else.
+        resolveToken: bytesFromBase64(resolveToken),
+        sendTime: now,
+        sdk: SDK,
+      };
+      await this.post('/v1/flags:apply', ApplyFlagsRequest.toJSON(request), options?.signal);
+      return { ok: true };
+    } catch (err) {
+      this.logger?.warn?.('Apply failed, exposure was not recorded. %s', String(err));
+      return {
+        ok: false,
+        errorCode: isTimeout(err) ? 'TIMEOUT' : 'GENERAL',
+        errorMessage: String(err),
+        status: err instanceof HttpError ? err.status : undefined,
+      };
+    }
+  }
+
+  private async post(path: string, body: unknown, signal?: AbortSignal): Promise<Response> {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!response.ok) {
+      // The resolver returns diagnostics as the body (e.g. "client secret not
+      // found: requested=..., available=[...]") — worth surfacing.
+      const detail = await response.text().catch(() => '');
+      throw new HttpError(
+        response.status,
+        `Confidence ${path} failed: ${response.status} ${response.statusText}${detail ? ` - ${detail}` : ''}`,
+      );
+    }
+    return response;
+  }
+}
+
+/**
+ * Carries the status through to {@link (ConfidenceClient:namespace).ApplyResult},
+ * so callers can tell 4xx from 5xx.
+ */
+class HttpError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+/**
+ * True for a signal that aborted on a deadline, as `AbortSignal.timeout()`
+ * produces. Some runtimes nest the reason under `cause` instead of surfacing it
+ * directly, so both are checked. A deliberate `controller.abort()` is an
+ * `AbortError` and deliberately not reported as a timeout.
+ */
+function isTimeout(err: unknown): boolean {
+  const { name, cause } = (err ?? {}) as { name?: unknown; cause?: { name?: unknown } };
+  return name === 'TimeoutError' || cause?.name === 'TimeoutError';
+}
+
+function createBundle({ resolveId, resolveToken, resolvedFlags }: ResolveFlagsResponse): FlagBundle {
+  const flags: FlagBundle['flags'] = {};
+  for (const { flag, reason, variant, value, shouldApply, assignmentOrigin } of resolvedFlags) {
+    flags[flag.slice(FLAG_PREFIX.length)] = {
+      reason: convertReason(reason),
+      variant,
+      value: (value ?? null) as FlagBundle.Struct | null,
+      shouldApply,
+      assignmentOrigin,
+    };
+  }
+
+  return { flags, resolveId, resolveToken: base64FromBytes(resolveToken) };
+}
+
+function erroredBundle(errorCode: FlagBundle.ErrorCode, errorMessage: string): FlagBundle {
+  return { flags: {}, resolveId: '', resolveToken: '', errorCode, errorMessage };
+}
+
+function convertReason(reason: ResolveReason): FlagBundle.Reason {
+  switch (reason) {
+    case ResolveReason.RESOLVE_REASON_ERROR:
+      return 'ERROR';
+    case ResolveReason.RESOLVE_REASON_FLAG_ARCHIVED:
+      return 'FLAG_ARCHIVED';
+    case ResolveReason.RESOLVE_REASON_MATCH:
+      return 'MATCH';
+    case ResolveReason.RESOLVE_REASON_NO_SEGMENT_MATCH:
+      return 'NO_SEGMENT_MATCH';
+    case ResolveReason.RESOLVE_REASON_TARGETING_KEY_ERROR:
+      return 'TARGETING_KEY_ERROR';
+    case ResolveReason.RESOLVE_REASON_NO_TREATMENT_MATCH:
+      return 'NO_TREATMENT_MATCH';
+    default:
+      return 'UNSPECIFIED';
+  }
+}

--- a/packages/sdk/src/FlagBundle.ts
+++ b/packages/sdk/src/FlagBundle.ts
@@ -1,0 +1,183 @@
+import { Logger } from './logger';
+
+/**
+ * The result of resolving a set of flags: plain JSON, so a server can resolve
+ * once and forward the whole thing to a browser to evaluate.
+ *
+ * Bundles are produced by `ConfidenceClient.resolve`. This module is pure — it
+ * has no transport and no credentials — so it is safe to reach for from browser
+ * code that only ever evaluates a forwarded bundle.
+ * @public
+ */
+export interface FlagBundle {
+  /** Resolved flags, keyed by flag name without the `flags/` prefix */
+  flags: Record<string, FlagBundle.Details<FlagBundle.Struct | null> | undefined>;
+  /** Unique identifier for the resolve that produced this bundle */
+  resolveId: string;
+  /**
+   * Base64 of the opaque token to pass to `ConfidenceClient.apply`. Empty when
+   * the resolve already applied.
+   */
+  resolveToken: string;
+  /** Set when the resolve failed; every evaluation then yields its default */
+  errorCode?: FlagBundle.ErrorCode;
+  /** Set when the resolve failed */
+  errorMessage?: string;
+}
+
+/**
+ * Types and evaluation for {@link (FlagBundle:interface)}
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export namespace FlagBundle {
+  /** Error code for a flag that could not be evaluated */
+  export type ErrorCode = 'FLAG_NOT_FOUND' | 'TYPE_MISMATCH' | 'TIMEOUT' | 'GENERAL';
+
+  /** Why a flag resolved the way it did */
+  export type Reason =
+    | 'ERROR'
+    | 'FLAG_ARCHIVED'
+    | 'MATCH'
+    | 'NO_SEGMENT_MATCH'
+    | 'TARGETING_KEY_ERROR'
+    | 'NO_TREATMENT_MATCH'
+    | 'UNSPECIFIED';
+
+  /** Primitive flag value */
+  export type Primitive = null | boolean | string | number;
+  /** Object flag value */
+  export type Struct = { [key: string]: Value };
+  /** A flag value. The resolver never returns arrays */
+  export type Value = Primitive | Struct;
+
+  /** The outcome of resolving or evaluating a single flag */
+  export interface Details<T> {
+    /** Why the flag resolved the way it did */
+    reason: Reason;
+    /** The resolved value, or the default when the flag could not be evaluated */
+    value: T;
+    /** The assigned variant, e.g. `flags/my-flag/variants/treatment` */
+    variant?: string;
+    /** Set when the flag could not be evaluated */
+    errorCode?: ErrorCode;
+    /** Set when the flag could not be evaluated */
+    errorMessage?: string;
+    /** Whether evaluating this flag should count as an exposure */
+    shouldApply: boolean;
+    /** The rule that produced the assignment */
+    assignmentOrigin?: string;
+  }
+
+  /**
+   * Evaluate a flag key against a resolved bundle, with a typed default.
+   *
+   * A pure function with no I/O — it works on a bundle that was JSON-forwarded
+   * from the server, so a browser can evaluate without resolving again. Never
+   * throws: errors surface as the default value with an `ERROR` reason.
+   *
+   * @param bundle - a bundle from `ConfidenceClient.resolve`
+   * @param flagKey - `'my-flag'` or a dot path into the value, `'my-flag.some.field'`
+   * @param defaultValue - returned whenever the flag cannot be evaluated
+   * @param logger - optional logger for evaluation failures
+   */
+  export function evaluate<T extends Value>(
+    bundle: FlagBundle,
+    flagKey: string,
+    defaultValue: T,
+    logger?: Logger,
+  ): Details<T> {
+    const [flagName, ...path] = flagKey.split('.');
+    const flag = bundle?.flags[flagName];
+
+    if (bundle?.errorCode) {
+      logger?.warn?.(`Flag evaluation for "%s" failed. %s %s`, flagKey, bundle.errorCode, bundle?.errorMessage);
+      return {
+        reason: 'ERROR',
+        errorCode: bundle.errorCode,
+        errorMessage: bundle.errorMessage,
+        value: defaultValue,
+        shouldApply: false,
+      };
+    }
+
+    if (!flag) {
+      logger?.warn?.(`Flag evaluation for '${flagKey}' failed: flag not found`);
+      return {
+        reason: 'ERROR',
+        errorCode: 'FLAG_NOT_FOUND',
+        value: defaultValue,
+        shouldApply: false,
+      };
+    }
+
+    let value: Value = flag.value;
+    for (let i = 0; i < path.length; i++) {
+      if (value === null || typeof value !== 'object') {
+        return {
+          reason: 'ERROR',
+          value: defaultValue,
+          errorCode: 'TYPE_MISMATCH',
+          errorMessage: `resolved value is not an object at ${[flagName, ...path.slice(0, i)].join('.')}`,
+          shouldApply: false,
+        };
+      }
+      value = value[path[i]];
+    }
+
+    try {
+      return {
+        ...flag,
+        value: evaluateAssignment(value, defaultValue, [flagName, ...path]),
+      };
+    } catch (e) {
+      return {
+        reason: 'ERROR',
+        value: defaultValue,
+        errorCode: 'TYPE_MISMATCH',
+        errorMessage: e instanceof Error ? e.message : String(e),
+        shouldApply: false,
+      };
+    }
+  }
+}
+
+function evaluateAssignment<T extends FlagBundle.Value>(
+  resolvedValue: FlagBundle.Value,
+  defaultValue: T,
+  path: string[],
+): T {
+  const resolvedType = typeof resolvedValue;
+  const defaultType = typeof defaultValue;
+
+  // Guards JS callers; TypeScript rejects array defaults at compile time.
+  if (Array.isArray(defaultValue)) {
+    throw new Error(`arrays are not supported as flag values at ${path.join('.')}`);
+  }
+
+  // If default is null, any value is acceptable
+  if (defaultValue === null) return resolvedValue as T;
+
+  // If resolved is null, substitute default
+  if (resolvedValue === null) return defaultValue;
+
+  if (resolvedType !== defaultType) {
+    throw new Error(
+      `resolved value (${resolvedType}) isn't assignable to default type (${defaultType}) at ${path.join('.')}`,
+    );
+  }
+
+  if (typeof resolvedValue === 'object') {
+    const result: FlagBundle.Struct = { ...resolvedValue };
+    for (const [key, value] of Object.entries(defaultValue as FlagBundle.Struct)) {
+      if (!(key in resolvedValue)) {
+        throw new Error(`resolved value is missing field "${key}" at ${path.join('.')}`);
+      }
+      result[key] = evaluateAssignment(resolvedValue[key], value, [...path, key]);
+    }
+    return result as T;
+  }
+
+  // Primitives — type match already validated
+  return resolvedValue as T;
+}

--- a/packages/sdk/src/FlagResolution.ts
+++ b/packages/sdk/src/FlagResolution.ts
@@ -1,5 +1,6 @@
 import { Schema } from './Schema';
 import { Value } from './Value';
+import { base64FromBytes } from './base64';
 import { TypeMismatchError } from './error';
 import { publishFlagEvaluation } from './flag-evaluation-global';
 import { FlagEvaluation } from './flags';
@@ -192,15 +193,4 @@ function toEvaluationReason(reason: ResolveReason): Exclude<FlagEvaluation<unkno
     default:
       return 'UNSPECIFIED';
   }
-}
-
-function base64FromBytes(arr: Uint8Array): string {
-  if ((globalThis as any).Buffer) {
-    return globalThis.Buffer.from(arr).toString('base64');
-  }
-  const bin: string[] = [];
-  arr.forEach(byte => {
-    bin.push(globalThis.String.fromCharCode(byte));
-  });
-  return globalThis.btoa(bin.join(''));
 }

--- a/packages/sdk/src/base64.ts
+++ b/packages/sdk/src/base64.ts
@@ -1,0 +1,57 @@
+/**
+ * Isomorphic base64 for binary data, used for the resolve token on the wire.
+ *
+ * Distinct from `utf8ToBase64` in `./utils`, which encodes a string and works in
+ * the browser only. These take and return bytes, and work in Node.js, browsers
+ * and Workers.
+ *
+ * This module has no imports on purpose: it is reached for from code that must
+ * not depend on the rest of the package.
+ */
+
+/** A Node `Buffer`: a `Uint8Array` that can stringify itself to an encoding. */
+type NodeBuffer = Uint8Array & { toString(encoding: string): string };
+
+/** The subset of Node's `Buffer` constructor used here. */
+type NodeBufferCtor = {
+  from(data: string, encoding: string): NodeBuffer;
+  from(data: Uint8Array): NodeBuffer;
+};
+
+/**
+ * Node's `Buffer`, absent in browsers and Workers.
+ *
+ * Typed here rather than relying on `globalThis` so the package does not need
+ * `@types/node` in scope — it also ships to the browser. Read per call rather
+ * than once at module scope, so tests can remove it.
+ */
+function nodeBuffer(): NodeBufferCtor | undefined {
+  return (globalThis as { Buffer?: NodeBufferCtor }).Buffer;
+}
+
+/** Decode a base64 string to bytes. Uses Buffer in Node.js, `atob` elsewhere. */
+export function bytesFromBase64(b64: string): Uint8Array {
+  const buffer = nodeBuffer();
+  if (buffer) {
+    return Uint8Array.from(buffer.from(b64, 'base64'));
+  }
+  const bin = globalThis.atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+/** Encode bytes to a base64 string. Uses Buffer in Node.js, `btoa` elsewhere. */
+export function base64FromBytes(arr: Uint8Array): string {
+  const buffer = nodeBuffer();
+  if (buffer) {
+    return buffer.from(arr).toString('base64');
+  }
+  const bin: string[] = [];
+  arr.forEach(byte => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return globalThis.btoa(bin.join(''));
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,3 +9,7 @@ export * from './Closer';
 export * from './types';
 export { SimpleFetch } from './fetch-util';
 export { CacheOptions, CacheScope } from './flag-cache';
+// Named explicitly rather than `export *`, so this surface stays deliberate.
+// ConfidenceClient carries its Options and ApplyResult types in a merged namespace.
+export { ConfidenceClient, EvaluationContext } from './ConfidenceClient';
+export { FlagBundle } from './FlagBundle';

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,7 +26,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "extra-files": ["src/Confidence.ts"]
+      "extra-files": ["src/Confidence.ts", "src/ConfidenceClient.ts"]
     },
     "csr/csr-common": {
       "component": "csr-common",


### PR DESCRIPTION
## Hi There, I just made a Pull Request!

Adds `ConfidenceClient` — a thin, stateless flag client for a remote resolver — as a new top-level export of `@spotify-confidence/sdk`. Ported from `confidence-resolver/openfeature-provider/js`, where it was originally written.

Flags only: resolve, evaluate, apply. No lifecycle, no background work, no cached state, so constructing one is free. Intended as the primitive the OpenFeature providers move onto once `Confidence` is retired — the deprecation notices are narrowed from "the SDK" to "the `Confidence` class" accordingly.

### New exports

- `ConfidenceClient` (+ `ConfidenceClient.Options` / `.ApplyResult`), `EvaluationContext`
- `FlagBundle` (+ `FlagBundle.evaluate`) — pure and dependency-free, so a server can resolve once and forward the bundle as JSON for the browser to evaluate

### Worth a look in review

- **Neither call rejects.** `resolve` returns an errored bundle that evaluates to defaults with an `ERROR` reason; `apply` returns `ApplyResult` rather than throwing, since the natural call site is fire-and-forget and an unhandled rejection kills the process on Node. `status` is exposed so callers can retry.
- **Signal only, no `timeout` option** — `AbortSignal.timeout()` covers deadlines and cancellation with one parameter. Deadline misses report `TIMEOUT`; a deliberate `abort()` does not. No built-in retry yet.
- **Context uses the wire spelling `targeting_key`**, not `targetingKey`.
- **Imports are deliberately limited** to generated protos, `./logger`, `./base64` and `./FlagBundle` — nothing from the `Confidence` graph, so the new code doesn't pin the old one alive.
- Adapted to this repo's older protos: `SDK_ID_JS_CONFIDENCE` (no thin-client id exists yet), and `MATERIALIZATION_NOT_SUPPORTED` / `UNRECOGNIZED_TARGETING_RULE` dropped from the reason union.

### Drive-by

- Extracted the base64 helpers to `base64.ts` and deleted the byte-identical private copy in `FlagResolution.ts`. Both relied on `globalThis.Buffer` resolving via `@types/node`, which only works because jest pulls it in — now typed locally (`TS7017` in editors otherwise).
- `api/sdk.api.md` regenerated; `release-please-config.json` gains `src/ConfidenceClient.ts` for its version literal.

#### :heavy_check_mark: Checklist

- [x] All tests are passing
- [x] Relevant documentation updated
- [x] linter/style run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes <!-- n/a -->
- [ ] Tested in a corresponding example app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
