### PR TITLE
fix(sdk): make ConfidenceClient usable from a Cloudflare Worker

### DIFF
--- a/packages/sdk/src/ConfidenceClient.e2e.test.ts
+++ b/packages/sdk/src/ConfidenceClient.e2e.test.ts
@@ -105,7 +105,10 @@ describe('ConfidenceClient E2E (resolve)', () => {
 
       const bundle = await bogus.resolve([FLAG], CONTEXT, { apply: false });
 
-      expect(bundle.errorMessage).toMatch(/flags:resolve failed: 4\d\d/);
+      // Status not pinned to 4xx — the Cloudflare edge resolver answers 500 for
+      // an unknown secret. What matters is that the diagnostic survives.
+      expect(bundle.errorCode).toBe('GENERAL');
+      expect(bundle.errorMessage).toMatch(/flags:resolve failed: \d{3}/);
       expect(FlagBundle.evaluate(bundle, FLAG, 'fallback')).toMatchObject({ reason: 'ERROR', value: 'fallback' });
     },
     TIMEOUT,
@@ -199,7 +202,18 @@ describe('ConfidenceClient E2E (apply)', () => {
   let resolveToken: string;
 
   beforeAll(async () => {
-    ({ resolveToken } = await client.resolve([FLAG], CONTEXT, { apply: false }));
+    const bundle = await client.resolve([FLAG], CONTEXT, { apply: false });
+
+    // Asserted here on purpose. `resolve` never rejects, so a transient failure
+    // would yield an errored bundle with an empty token; `apply` then
+    // short-circuits to `{ ok: true }` without a request, which passes the
+    // positive tests below vacuously and fails the negative ones with a
+    // baffling "expected ok: false, received ok: true". Failing in the hook
+    // instead points at the real cause and prints the resolver's diagnostic.
+    expect(bundle.errorMessage).toBeUndefined();
+    expect(bundle.resolveToken).toBeTruthy();
+
+    ({ resolveToken } = bundle);
   }, TIMEOUT);
 
   it(
@@ -219,15 +233,18 @@ describe('ConfidenceClient E2E (apply)', () => {
   );
 
   it(
-    'reports a resolve token the resolver will not accept, with a 4xx status',
+    'reports a resolve token the resolver will not accept, carrying the HTTP status',
     async () => {
       const result = await client.apply('bm90LWEtdG9rZW4=', FLAG);
 
       expect(result).toMatchObject({ ok: false, errorCode: 'GENERAL' });
-      // A permanent failure: the status is what tells a caller not to retry.
+      // Deliberately not pinned to 4xx. The status is there so a caller can log
+      // or branch on it, but it is not a portable retry signal: this resolver
+      // answers 4xx, while the Cloudflare edge resolver returns 500 for the
+      // same permanently-doomed apply (confidence-cloudflare-resolver
+      // src/lib.rs maps every apply error to 500).
       expect(result.ok === false && result.status).toBeGreaterThanOrEqual(400);
-      expect(result.ok === false && result.status).toBeLessThan(500);
-      expect(result.ok === false && result.errorMessage).toMatch(/flags:apply failed: 4\d\d/);
+      expect(result.ok === false && result.errorMessage).toMatch(/flags:apply failed: \d{3}/);
     },
     TIMEOUT,
   );
@@ -240,7 +257,9 @@ describe('ConfidenceClient E2E (apply)', () => {
       // round-trip through the browser.
       const result = await client.apply(resolveToken, OTHER_FLAG);
 
-      expect(result).toMatchObject({ ok: false, status: 400 });
+      // The diagnostic is the portable part; the status is not (see above).
+      expect(result).toMatchObject({ ok: false, errorCode: 'GENERAL' });
+      expect(result.ok === false && result.status).toBeGreaterThanOrEqual(400);
       expect(result.ok === false && result.errorMessage).toMatch(
         /Flag in resolve token does not match flag in request/,
       );
@@ -255,7 +274,8 @@ describe('ConfidenceClient E2E (apply)', () => {
       // carry — an apply naming a flag it never resolved isn't partly right.
       const result = await client.apply(resolveToken, [FLAG, OTHER_FLAG]);
 
-      expect(result).toMatchObject({ ok: false, status: 400 });
+      expect(result).toMatchObject({ ok: false, errorCode: 'GENERAL' });
+      expect(result.ok === false && result.status).toBeGreaterThanOrEqual(400);
       expect(result.ok === false && result.errorMessage).toMatch(
         /Flag in resolve token does not match flag in request/,
       );

--- a/packages/sdk/src/ConfidenceClient.test.ts
+++ b/packages/sdk/src/ConfidenceClient.test.ts
@@ -221,6 +221,14 @@ describe('ConfidenceClient', () => {
       await client(fetchImpl, 'https://my-resolver.example.com//').resolve(['promo-banner'], {});
       expect((fetchImpl as any).mock.calls[0][0]).toBe('https://my-resolver.example.com/v1/flags:resolve');
     });
+
+    it('falls back to the default url for an empty one', async () => {
+      // A service binding ignores the hostname, which invites passing '' — but
+      // neither `fetch` nor a binding can send a relative URL.
+      const fetchImpl = mockTransport();
+      await client(fetchImpl, '').resolve(['promo-banner'], {});
+      expect((fetchImpl as any).mock.calls[0][0]).toBe('https://resolver.confidence.dev/v1/flags:resolve');
+    });
   });
 
   describe('apply', () => {
@@ -391,6 +399,61 @@ describe('ConfidenceClient', () => {
       const instance = client(mockTransport()) as unknown as Record<string, unknown>;
       expect(instance.initialize).toBeUndefined();
       expect(instance.close).toBeUndefined();
+    });
+  });
+
+  describe('default transport', () => {
+    /**
+     * Cloudflare Workers reject a `fetch` called with the wrong receiver
+     * ("Illegal invocation"), so a client that captured the bare
+     * `globalThis.fetch` fails every request from inside a Worker. Node and
+     * browsers are lenient, which is why only a real Worker caught this.
+     */
+    function installStrictReceiverFetch(impl: typeof fetch) {
+      const original = globalThis.fetch;
+      // Not an arrow: the point is to observe the receiver the client calls with.
+      const strict = function strictFetch(this: unknown, ...args: Parameters<typeof fetch>) {
+        if (this !== globalThis) {
+          throw new TypeError('Illegal invocation: function called with incorrect `this` reference.');
+        }
+        return impl(...args);
+      };
+      globalThis.fetch = strict as unknown as typeof fetch;
+      return () => {
+        globalThis.fetch = original;
+      };
+    }
+
+    it('calls the global fetch with the global as receiver', async () => {
+      const fetchImpl = mockTransport();
+      const restore = installStrictReceiverFetch(fetchImpl);
+      try {
+        const bundle = await new ConfidenceClient({ flagClientSecret: SECRET }).resolve(['promo-banner'], {});
+
+        expect(bundle.errorCode).toBeUndefined();
+        expect(bundle.flags['promo-banner']).toMatchObject({ reason: 'MATCH' });
+      } finally {
+        restore();
+      }
+    });
+
+    it('reads the global fetch per call, so construction needs no global', async () => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+      // @ts-expect-error — deliberately removing fetch to mimic a runtime without it
+      delete globalThis.fetch;
+      try {
+        const instance = new ConfidenceClient({ flagClientSecret: SECRET });
+        expect(instance).toBeDefined();
+
+        const restore = installStrictReceiverFetch(mockTransport());
+        try {
+          expect((await instance.resolve(['promo-banner'], {})).errorCode).toBeUndefined();
+        } finally {
+          restore();
+        }
+      } finally {
+        if (originalDescriptor) Object.defineProperty(globalThis, 'fetch', originalDescriptor);
+      }
     });
   });
 });

--- a/packages/sdk/src/ConfidenceClient.ts
+++ b/packages/sdk/src/ConfidenceClient.ts
@@ -50,7 +50,12 @@ export namespace ConfidenceClient {
      * Defaults to `https://resolver.confidence.dev`.
      */
     url?: string;
-    /** fetch-compatible transport. Pass a Cloudflare service binding here. */
+    /**
+     * fetch-compatible transport. To use a Cloudflare service binding, wrap it
+     * rather than passing the method itself — a detached `fetch` loses its
+     * receiver and Workers rejects it with "Illegal invocation":
+     * `fetch: (...args) => env.ConfidenceBinding.fetch(...args)`.
+     */
     fetch?: typeof fetch;
     /** Optional logger. Nothing is logged when omitted. */
     logger?: Logger;
@@ -91,9 +96,17 @@ export class ConfidenceClient {
   /** Create a client. Does no work */
   constructor(options: ConfidenceClient.Options) {
     this.clientSecret = options.flagClientSecret;
-    // Trailing slashes would produce '//v1/flags:resolve'.
-    this.baseUrl = (options.url ?? DEFAULT_URL).replace(/\/+$/, '');
-    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    // Trailing slashes would produce '//v1/flags:resolve'. `||` rather than
+    // `??` so an empty string falls back too: over a service binding the
+    // hostname is ignored, which invites passing '' — and a relative URL is not
+    // something `fetch` or a binding can send.
+    this.baseUrl = (options.url || DEFAULT_URL).replace(/\/+$/, '');
+    // Wrapped, not `globalThis.fetch` directly: Cloudflare Workers reject a
+    // detached `fetch` with "Illegal invocation: function called with incorrect
+    // `this` reference", so capturing the bare function breaks every request
+    // from inside a Worker. Resolved per call rather than bound here, so
+    // constructing still does no work when the runtime has no global fetch.
+    this.fetchImpl = options.fetch ?? ((...args) => globalThis.fetch(...args));
     this.logger = options.logger;
   }
 


### PR DESCRIPTION
Follow-up to #426, found by actually running the new `ConfidenceClient` inside a deployed Cloudflare Worker.

## The bug

`ConfidenceClient` captured `globalThis.fetch` as a bare function reference:

```ts
this.fetchImpl = options.fetch ?? globalThis.fetch;
```

Cloudflare Workers reject a detached `fetch`, so **every** resolve and apply from inside a Worker failed:

```
TypeError: Illegal invocation: function called with incorrect `this` reference.
```

And it failed *silently*. `resolve` never rejects, so the caller got an errored bundle, every flag fell back to its default, and nothing was logged unless a `logger` was passed. This hit the deployment the class docstring advertises — "`resolver.confidence.dev` over HTTP" from a Worker.

Node and browsers are lenient about the receiver, which is why the unit and e2e suites both missed it.

## Changes

- **`fetch` receiver**: wrap rather than capture — `options.fetch ?? ((...args) => globalThis.fetch(...args))`. Wrapped rather than `.bind()`ed so construction still does no work in a runtime with no global `fetch`, as the docstring promises.
- **`url: ''`**: `??` kept the empty string, making the request URL the relative `/v1/flags:resolve`, which neither `fetch` nor a service binding can send. A binding ignoring the hostname is exactly what invites passing `''`, so `||` now falls back to the default.
- **`fetch` option doc**: passing `env.Binding.fetch` fails for the same receiver reason, so it now shows the wrapped form `(...args) => env.ConfidenceBinding.fetch(...args)`.
- **e2e: hardened the apply `beforeAll`** to assert its resolve succeeded. A transient failure there yields an empty token, `apply` short-circuits to `{ ok: true }` without a request, and the negative-path tests fail with a baffling "expected ok: false, received ok: true" — which is exactly the CI failure that started this. It now fails in the hook and prints the resolver's diagnostic.
- **e2e: unpinned the apply status assertions** from 400. The status is not a portable retry signal: `resolver.confidence.dev` answers 4xx where the Cloudflare edge resolver returns 500 for the same permanently-doomed apply.

## Verification

Reproduced and confirmed fixed on a **deployed** Worker, service-bound to a Confidence Cloudflare resolver built with `FORCE_APPLY=false` (queue producer + consumer, both KV namespaces, encryption key as a Worker secret):

| | before | after |
|---|---|---|
| default `fetch`, HTTPS from a Worker | `Illegal invocation`, no token | resolves, 532-char token |
| `url: ''` over a service binding | `TypeError: Invalid URL: /v1/flags:resolve` | resolves |

- New unit tests install a strict-receiver global `fetch` to reproduce the Workers behavior; all three added tests fail against the old code.
- `yarn test`: 213 passed. `yarn test:e2e`: `ConfidenceClient.e2e.test.ts` passes in full. `yarn lint`, `yarn build`: clean.
- The `beforeAll` hardening was verified by temporarily pointing that resolve at a bad secret — all six apply tests then reported `flags:resolve failed: 401 Unauthorized` instead of the misleading `ok: true` mismatch.

## Notes for review

- Unpinning the status trades away a contract check on the managed resolver: if it ever changed 400 → 500 for a rejected token, these tests would no longer catch it. Happy to pin 4xx back with a comment naming the resolver instead.
- Separately worth considering, not changed here: `apply()` returns `{ ok: true }` for an empty token, conflating "nothing to do" with "the token never arrived". Related, the Cloudflare resolver deployed with its default `FORCE_APPLY=true` makes `resolve(..., { apply: false })` return `shouldApply: true` with an empty token, so the deferred flow degrades invisibly.
- Also observed: over a service binding, a warm call can complete in **under a millisecond**, so `AbortSignal.timeout(1)` is a coin flip there. The comment at `ConfidenceClient.e2e.test.ts:123` ("1ms is unreachable over the network") holds over HTTP but should not be copied into any binding-based test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)